### PR TITLE
 ChatSessionRepository [#44]

### DIFF
--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Reset Docker auth
+        run: |
+          rm -f ~/.docker/config.json
+          docker logout docker.io || true
+          docker logout https://index.docker.io/v1/ || true
+
       - name: Restore
         run: dotnet restore backend/ShuKnow.sln
 

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/BaseRepositoryTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/BaseRepositoryTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ShuKnow.Infrastructure.Persistent;
+using Testcontainers.PostgreSql;
+
+namespace ShuKnow.Infrastructure.IntegrationTests.Persistent.Repositories;
+
+public class BaseRepositoryTests
+{
+    protected AppDbContext Context = null!;
+    
+    private PostgreSqlContainer postgresContainer = null!;
+    private DbContextOptions<AppDbContext> dbContextOptions = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        postgresContainer = new PostgreSqlBuilder("postgres:16-alpine")
+            .WithDatabase("shuknow_integration_tests")
+            .WithUsername("postgres")
+            .WithPassword("postgres")
+            .Build();
+
+        await postgresContainer.StartAsync();
+
+        dbContextOptions = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(postgresContainer.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        await using var migrationContext = CreateDbContext();
+        await migrationContext.Database.MigrateAsync();
+    }
+    
+    [SetUp]
+    public virtual async Task SetUp()
+    {
+        await ResetDatabaseAsync();
+        Context = CreateDbContext();
+    }
+    
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (Context is not null) 
+            await Context.DisposeAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (postgresContainer is not null) 
+            await postgresContainer.DisposeAsync();
+    }
+    
+    protected AppDbContext CreateDbContext()
+    {
+        return new AppDbContext(dbContextOptions);
+    }
+    
+    private async Task ResetDatabaseAsync()
+    {
+        await using var resetContext = CreateDbContext();
+        
+        resetContext.RemoveRange(resetContext.Users);
+        resetContext.RemoveRange(resetContext.IdentityUsers);
+        resetContext.RemoveRange(resetContext.ChatSessions);
+        await resetContext.SaveChangesAsync();
+    }
+}

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/ChatSessionRepositoryTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/ChatSessionRepositoryTests.cs
@@ -1,0 +1,142 @@
+using Ardalis.Result;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using ShuKnow.Domain.Entities;
+using ShuKnow.Domain.Enums;
+using ShuKnow.Infrastructure.Persistent.Repositories;
+
+namespace ShuKnow.Infrastructure.IntegrationTests.Persistent.Repositories;
+
+public class ChatSessionRepositoryTests : BaseRepositoryTests
+{
+    private ChatSessionRepository sut = null!;
+    
+    public override async Task SetUp()
+    {
+        await base.SetUp();
+        sut = new ChatSessionRepository(Context);
+    }
+
+    [Test]
+    public async Task GetActiveAsync_WhenActiveSessionExists_ShouldReturnSessionWithoutTracking()
+    {
+        var user = await SeedUserAsync();
+        var activeSession = await SeedSessionAsync(user.Id);
+        await SeedSessionAsync(user.Id, ChatSessionStatus.Closed);
+
+        var result = await sut.GetActiveAsync(user.Id);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Id.Should().Be(activeSession.Id);
+        result.Value.UserId.Should().Be(user.Id);
+        result.Value.Status.Should().Be(ChatSessionStatus.Active);
+        Context.ChangeTracker.Entries<ChatSession>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetActiveAsync_WhenOnlyClosedSessionExists_ShouldReturnNotFound()
+    {
+        var user = await SeedUserAsync();
+        await SeedSessionAsync(user.Id, ChatSessionStatus.Closed);
+
+        var result = await sut.GetActiveAsync(user.Id);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        Context.ChangeTracker.Entries<ChatSession>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AddAsync_WhenCommitted_ShouldPersistSession()
+    {
+        var user = await SeedUserAsync();
+        var session = new ChatSession(Guid.NewGuid(), user.Id);
+
+        var result = await sut.AddAsync(session);
+        await Context.SaveChangesAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+
+        await using var assertContext = CreateDbContext();
+        var persistedSession = await assertContext.ChatSessions.SingleAsync(existing => existing.Id == session.Id);
+
+        persistedSession.UserId.Should().Be(user.Id);
+        persistedSession.Status.Should().Be(ChatSessionStatus.Active);
+    }
+
+    [Test]
+    public async Task AddAsync_WhenUserAlreadyHasActiveSession_ShouldFailOnSave()
+    {
+        var user = await SeedUserAsync();
+        await SeedSessionAsync(user.Id);
+
+        var anotherActiveSession = new ChatSession(Guid.NewGuid(), user.Id);
+
+        var result = await sut.AddAsync(anotherActiveSession);
+        var act = async () => await Context.SaveChangesAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenSessionIsTracked_ShouldDeleteSession()
+    {
+        var user = await SeedUserAsync();
+        var session = await SeedSessionAsync(user.Id);
+        var trackedSession = await Context.ChatSessions.SingleAsync(existing => existing.Id == session.Id);
+
+        var result = await sut.DeleteAsync(session.Id);
+        await Context.SaveChangesAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        Context.Entry(trackedSession).State.Should().Be(EntityState.Detached);
+
+        await using var assertContext = CreateDbContext();
+        var exists = await assertContext.ChatSessions.AnyAsync(existing => existing.Id == session.Id);
+        exists.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenSessionIsNotTracked_ShouldDeleteSession()
+    {
+        var user = await SeedUserAsync();
+        var session = await SeedSessionAsync(user.Id);
+
+        var result = await sut.DeleteAsync(session.Id);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        Context.ChangeTracker.Entries<ChatSession>().Should().ContainSingle(entry =>
+            entry.Entity.Id == session.Id && entry.State == EntityState.Deleted);
+
+        await Context.SaveChangesAsync();
+
+        await using var assertContext = CreateDbContext();
+        var exists = await assertContext.ChatSessions.AnyAsync(existing => existing.Id == session.Id);
+        exists.Should().BeFalse();
+    }
+
+    private async Task<User> SeedUserAsync(Guid? userId = null)
+    {
+        var user = new User(userId ?? Guid.NewGuid());
+
+        await using var seedContext = CreateDbContext();
+        seedContext.Users.Add(user);
+        await seedContext.SaveChangesAsync();
+
+        return user;
+    }
+
+    private async Task<ChatSession> SeedSessionAsync(
+        Guid userId,
+        ChatSessionStatus status = ChatSessionStatus.Active,
+        Guid? sessionId = null)
+    {
+        var session = new ChatSession(sessionId ?? Guid.NewGuid(), userId, status);
+
+        await using var seedContext = CreateDbContext();
+        seedContext.ChatSessions.Add(session);
+        await seedContext.SaveChangesAsync();
+
+        return session;
+    }
+}

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/ShuKnow.Infrastructure.IntegrationTests.csproj
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/ShuKnow.Infrastructure.IntegrationTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ShuKnow.Infrastructure\ShuKnow.Infrastructure.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class ServiceCollectionExtensions
         {
             var connectionString = configuration.GetConnectionString("Postgres");
             options
-                .UseNpgsql(connectionString)
+                .UseNpgsql(connectionString, builder => builder.EnableRetryOnFailure())
                 .UseSnakeCaseNamingConvention();
         });
 

--- a/backend/ShuKnow.Infrastructure/Migrations/20260327123028_AddChatSessions.Designer.cs
+++ b/backend/ShuKnow.Infrastructure/Migrations/20260327123028_AddChatSessions.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ShuKnow.Infrastructure.Persistent;
@@ -11,9 +12,11 @@ using ShuKnow.Infrastructure.Persistent;
 namespace ShuKnow.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260327123028_AddChatSessions")]
+    partial class AddChatSessions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/ShuKnow.Infrastructure/Migrations/20260327123028_AddChatSessions.cs
+++ b/backend/ShuKnow.Infrastructure/Migrations/20260327123028_AddChatSessions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShuKnow.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChatSessions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "chat_sessions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_chat_sessions", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_chat_sessions_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chat_sessions_user_id",
+                table: "chat_sessions",
+                column: "user_id",
+                unique: true,
+                filter: "\"status\" = 1");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "chat_sessions");
+        }
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Persistent/AppDbContext.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/AppDbContext.cs
@@ -8,6 +8,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 {
     public DbSet<User> Users { get; set; }
     public DbSet<IdentityUser> IdentityUsers { get; set; }
+    public DbSet<ChatSession> ChatSessions { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -28,6 +29,27 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
                 .WithOne()
                 .HasForeignKey<IdentityUser>(iu => iu.Id)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ChatSession>(entity =>
+        {
+            entity.ToTable("chat_sessions");
+            entity.HasKey(session => session.Id);
+
+            entity.Property(session => session.Status)
+                .HasConversion<int>();
+
+            entity.HasIndex(session => session.UserId)
+                .HasFilter("\"status\" = 1")
+                .IsUnique();
+
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(session => session.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // TODO: убрать после реализации ChatMessageRepository
+            entity.Ignore(session => session.Messages);
         });
     }
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatSessionRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatSessionRepository.cs
@@ -1,23 +1,43 @@
 using Ardalis.Result;
+using Microsoft.EntityFrameworkCore;
 using ShuKnow.Domain.Entities;
+using ShuKnow.Domain.Enums;
 using ShuKnow.Domain.Repositories;
 
 namespace ShuKnow.Infrastructure.Persistent.Repositories;
 
-public class ChatSessionRepository : IChatSessionRepository
+public class ChatSessionRepository(AppDbContext context) : IChatSessionRepository
 {
-    public Task<Result<ChatSession>> GetActiveAsync(Guid userId)
+    public async Task<Result<ChatSession>> GetActiveAsync(Guid userId)
     {
-        throw new NotImplementedException();
+        var session = await context.ChatSessions
+            .AsNoTracking()
+            .SingleOrDefaultAsync(session =>
+                session.UserId == userId &&
+                session.Status == ChatSessionStatus.Active);
+
+        return session is null ? Result.NotFound() : Result.Success(session);
     }
 
     public Task<Result> AddAsync(ChatSession session)
     {
-        throw new NotImplementedException();
+        context.ChatSessions.Add(session);
+        return Task.FromResult(Result.Success());
     }
 
     public Task<Result> DeleteAsync(Guid sessionId)
     {
-        throw new NotImplementedException();
+        var trackedSessionEntry = context.ChangeTracker
+            .Entries<ChatSession>()
+            .SingleOrDefault(entry => entry.Entity.Id == sessionId);
+
+        if (trackedSessionEntry is not null)
+        {
+            trackedSessionEntry.State = EntityState.Deleted;
+            return Task.FromResult(Result.Success());
+        }
+
+        context.ChatSessions.Remove(new ChatSession(sessionId, Guid.Empty, ChatSessionStatus.Closed));
+        return Task.FromResult(Result.Success());
     }
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatSessionRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatSessionRepository.cs
@@ -12,9 +12,7 @@ public class ChatSessionRepository(AppDbContext context) : IChatSessionRepositor
     {
         var session = await context.ChatSessions
             .AsNoTracking()
-            .SingleOrDefaultAsync(session =>
-                session.UserId == userId &&
-                session.Status == ChatSessionStatus.Active);
+            .SingleOrDefaultAsync(session => session.UserId == userId && session.Status == ChatSessionStatus.Active);
 
         return session is null ? Result.NotFound() : Result.Success(session);
     }

--- a/backend/ShuKnow.Infrastructure/Services/UnitOfWork.cs
+++ b/backend/ShuKnow.Infrastructure/Services/UnitOfWork.cs
@@ -1,12 +1,13 @@
 ﻿using Ardalis.Result;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Infrastructure.Persistent;
 
 namespace ShuKnow.Infrastructure.Services;
 
-public class UnitOfWork(AppDbContext context) : IUnitOfWork
+public class UnitOfWork(AppDbContext context, ILogger<UnitOfWork> logger) : IUnitOfWork
 {
     public async Task<Result> SaveChangesAsync()
     {
@@ -15,15 +16,22 @@ public class UnitOfWork(AppDbContext context) : IUnitOfWork
             await context.SaveChangesAsync();
             return Result.Success();
         }
-        catch (DbUpdateException e)
+        catch (DbUpdateConcurrencyException ex)
         {
-            if (e.InnerException is not PostgresException postgresException)
-                throw;
-
-            switch (postgresException.SqlState)
+            logger.LogWarning(ex, "Concurrency conflict during SaveChanges");
+            return Result.Conflict("The record was modified by another request. Please retry.");
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException pg)
+        {
+            logger.LogWarning(ex, 
+                "Database constraint violation: {SqlState}, constraint: {ConstraintName}, schema: {Schema}, " +
+                "Table: {Table}, Column: {Column}, at: {Where}",
+                pg.SqlState, pg.ConstraintName, pg.SchemaName, pg.TableName, pg.ColumnName, pg.Where);
+            
+            switch (pg.SqlState)
             {
                 case PostgresErrorCodes.UniqueViolation:
-                    return Result.Conflict("A conflict occurred: unique constraint violation.");
+                    return Result.Conflict("A data conflict occurred. Please retry.");
                 case PostgresErrorCodes.ForeignKeyViolation:
                     return Result.Error("A database error occurred: foreign key constraint violation.");
                 default:

--- a/backend/ShuKnow.WebAPI/Configuration/GlobalExceptionHandler.cs
+++ b/backend/ShuKnow.WebAPI/Configuration/GlobalExceptionHandler.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using ProblemDetails = Microsoft.AspNetCore.Mvc.ProblemDetails;
+
+namespace ShuKnow.WebAPI.Configuration;
+
+public class GlobalExceptionHandler(IHostEnvironment environment) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken ct)
+    {
+        var details = new ProblemDetails
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Title = "An unexpected error occurred",
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+            Instance = httpContext.Request.Path
+        };
+
+        if (environment.IsDevelopment())
+            details.Detail = exception.ToString();
+
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        await httpContext.Response.WriteAsJsonAsync(details, ct);
+        return true;
+    }
+}

--- a/backend/ShuKnow.WebAPI/Configuration/GlobalExceptionHandler.cs
+++ b/backend/ShuKnow.WebAPI/Configuration/GlobalExceptionHandler.cs
@@ -14,7 +14,8 @@ public class GlobalExceptionHandler(IHostEnvironment environment) : IExceptionHa
             Status = StatusCodes.Status500InternalServerError,
             Title = "An unexpected error occurred",
             Type = "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            Instance = httpContext.Request.Path
+            Instance = httpContext.Request.Path,
+            Extensions = { ["traceId"] = httpContext.TraceIdentifier }
         };
 
         if (environment.IsDevelopment())

--- a/backend/ShuKnow.WebAPI/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.WebAPI/Configuration/ServiceCollectionExtensions.cs
@@ -22,6 +22,9 @@ public static class ServiceCollectionExtensions
 {
     public static void AddWeb(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddExceptionHandler<GlobalExceptionHandler>();
+        services.AddProblemDetails();
+        
         services.AddControllers().AddApplicationPart(typeof(ServiceCollectionExtensions).Assembly);
         services.AddSignalR();
 

--- a/backend/ShuKnow.WebAPI/Configuration/WebApplicationExtensions.cs
+++ b/backend/ShuKnow.WebAPI/Configuration/WebApplicationExtensions.cs
@@ -1,12 +1,15 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Saunter;
 using ShuKnow.WebAPI.Hubs;
+
 namespace ShuKnow.WebAPI.Configuration;
 
 public static class WebApplicationExtensions
 {
     public static void UseWeb(this WebApplication app)
     {
+        app.UseExceptionHandler();
+        
         app.UseHttpsRedirection();
         app.UseAuthentication();
         app.UseAuthorization();

--- a/backend/ShuKnow.sln
+++ b/backend/ShuKnow.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShuKnow.WebAPI", "ShuKnow.W
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShuKnow.Application.Tests", "ShuKnow.Application.Tests\ShuKnow.Application.Tests.csproj", "{5104ADFC-BB06-4034-A076-16CDC6869117}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShuKnow.Infrastructure.IntegrationTests", "ShuKnow.Infrastructure.IntegrationTests\ShuKnow.Infrastructure.IntegrationTests.csproj", "{96F140AB-23E1-4092-BB16-EBB3BD6BF992}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +44,9 @@ Global
 		{5104ADFC-BB06-4034-A076-16CDC6869117}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5104ADFC-BB06-4034-A076-16CDC6869117}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5104ADFC-BB06-4034-A076-16CDC6869117}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96F140AB-23E1-4092-BB16-EBB3BD6BF992}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96F140AB-23E1-4092-BB16-EBB3BD6BF992}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96F140AB-23E1-4092-BB16-EBB3BD6BF992}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96F140AB-23E1-4092-BB16-EBB3BD6BF992}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Resolves #44

# Что сделано перед основной задачи
- добавил глобальный хэндлер ошибок, чтобы при неожиданной ошибке клиенту (т.е. фронтенду) отправлялся чуть более понятный ответ (и отправлялся стектрейс, если в Development)
- улучшил хэндлинг ошибок при сохранении в UnitOfWork + включил встроенный retry к бд при fail

# Что сделано в рамках задачи
- Реализован репозиторий, прописана модель, проведена миграция
- Написаны 6 интеграционных тестов. В качестве бд в них используется Testcontainers.PostgreSQL (+ ещё сделал базовый класс для тестов)

# Насчёт хэндлинга ошибок и всего остального
Я почитал разный материал из разных источников, почитал ответы разных ллм, вспомнил, что там и как было в ParallAI, а также, что говорил Никита. Ниже моё мнение.

Я считаю, что хэндлить ошибки прямо в репозитории не нужно. 

Во-первых, для write операций, если не ошибаюсь, ты этого просто не сделаешь, так как запись происходит в UnitOfWork. Там базовый хэндлинг уже есть.

Во-вторых, у нас могут быть лишь следующие ошибки:
- Нарушен инвариант ("юзер с таким айди уже существует") => про это написал в 3ем пункте.
- Произошла временная проблема с соединением к бд => делаем retry через встроенные возможности npgsql
- Нет доступа к БД ну совсем => отхэндлить это никак, только попытаться пару раз приконнектиться, а затем залоггировать ошибку и отправить юзеру ошибку 500 (так я и реализовал). Клиенту (т.е. фронтенду) вообще не важно, что там произошло с сервером (максимум, в Development, и то это проще в консоси глянуть), а подробности про инфру писать небезопасно.
- Какие-то другие неожиданные ошибки => вновь никак не отхэндлить, это уже проблема бэкендера => возвращаемся в предыдущий случай.

В-третьих, проверкой на инварианты (например, а владеет ли юзер данной папкой, а существует ли такая папка и т.д.) должны заниматься сервисы. И да, безусловно, это будет уже не в 1 SQL запрос, а в 2 запроса, но проверки на существование в современных БД достаточно оптимизированы, чтобы забить на это.

Кроме того, как я уже сказал выше, в репозитории не стоит выносить Application логику. Репозитории это просто тонкая и удобная прослойка между бд и проектом.

Могу быть в чём-то не прав, готов обсудить этот вопрос