### PR TITLE
BlobStorage [#67]

### DIFF
--- a/backend/ShuKnow.Application.Tests/Services/AttachmentServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/AttachmentServiceTests.cs
@@ -1,6 +1,5 @@
 using Ardalis.Result;
 using AwesomeAssertions;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Application.Services;
@@ -13,9 +12,9 @@ public class AttachmentServiceTests
 {
     private IAttachmentRepository attachmentRepository = null!;
     private IBlobStorageService blobStorageService = null!;
+    private IBlobDeletionQueue blobDeletionQueue = null!;
     private ICurrentUserService currentUserService = null!;
     private IUnitOfWork unitOfWork = null!;
-    private ILogger<AttachmentService> logger = null!;
     private Guid currentUserId;
     private AttachmentService sut = null!;
 
@@ -24,33 +23,19 @@ public class AttachmentServiceTests
     {
         attachmentRepository = Substitute.For<IAttachmentRepository>();
         blobStorageService = Substitute.For<IBlobStorageService>();
+        blobDeletionQueue = Substitute.For<IBlobDeletionQueue>();
         currentUserService = Substitute.For<ICurrentUserService>();
         unitOfWork = Substitute.For<IUnitOfWork>();
-        logger = Substitute.For<ILogger<AttachmentService>>();
         currentUserId = Guid.NewGuid();
 
         currentUserService.UserId.Returns(currentUserId);
         unitOfWork.SaveChangesAsync().Returns(Task.FromResult(Result.Success()));
         blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Success());
-        blobStorageService.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(Success());
+        blobDeletionQueue.EnqueueDeleteAsync(Arg.Any<Guid>()).Returns(ValueTask.CompletedTask);
 
         sut = new AttachmentService(
-            attachmentRepository, blobStorageService, currentUserService, unitOfWork, logger);
-    }
-
-    [Test]
-    public async Task UploadAsync_WhenCountsMismatch_ShouldReturnInvalid()
-    {
-        var attachments = new[] { CreateAttachment() };
-        var contents = Array.Empty<Stream>();
-
-        var result = await sut.UploadAsync(attachments, contents);
-
-        result.Status.Should().Be(ResultStatus.Invalid);
-        await attachmentRepository.DidNotReceive()
-            .AddRangeAsync(Arg.Any<IReadOnlyCollection<ChatAttachment>>());
+            attachmentRepository, blobStorageService, blobDeletionQueue, currentUserService, unitOfWork);
     }
 
     [Test]
@@ -58,14 +43,16 @@ public class AttachmentServiceTests
     {
         var first = CreateAttachment();
         var second = CreateAttachment();
-        var attachments = new[] { first, second };
         using var stream1 = new MemoryStream([1, 2, 3]);
         using var stream2 = new MemoryStream([4, 5]);
-        var contents = new[] { stream1, stream2 };
+        (ChatAttachment Attachment, Stream Content)[] uploads = [(first, stream1), (second, stream2)];
+        IReadOnlyCollection<ChatAttachment> attachments = [first, second];
 
-        attachmentRepository.AddRangeAsync(attachments).Returns(Success());
+        attachmentRepository.AddRangeAsync(Arg.Is<IReadOnlyCollection<ChatAttachment>>(items =>
+                items.Count == 2 && items.Contains(first) && items.Contains(second)))
+            .Returns(Success());
 
-        var result = await sut.UploadAsync(attachments, contents);
+        var result = await sut.UploadAsync(uploads);
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().HaveCount(2);
@@ -73,7 +60,9 @@ public class AttachmentServiceTests
         result.Value.Should().Contain(second);
         first.BlobId.Should().NotBe(Guid.Empty);
         second.BlobId.Should().NotBe(Guid.Empty);
-        await attachmentRepository.Received(1).AddRangeAsync(attachments);
+        await attachmentRepository.Received(1).AddRangeAsync(
+            Arg.Is<IReadOnlyCollection<ChatAttachment>>(items =>
+                items.Count == 2 && items.Contains(first) && items.Contains(second)));
         await blobStorageService.Received(1).SaveAsync(stream1, first.BlobId, Arg.Any<CancellationToken>());
         await blobStorageService.Received(1).SaveAsync(stream2, second.BlobId, Arg.Any<CancellationToken>());
         await unitOfWork.Received(1).SaveChangesAsync();
@@ -88,7 +77,7 @@ public class AttachmentServiceTests
         attachmentRepository.AddRangeAsync(Arg.Any<IReadOnlyCollection<ChatAttachment>>())
             .Returns(Task.FromResult(Result.Error("db error")));
 
-        var result = await sut.UploadAsync([attachment], [stream]);
+        var result = await sut.UploadAsync([(attachment, (Stream)stream)]);
 
         result.Status.Should().Be(ResultStatus.Error);
         await unitOfWork.DidNotReceive().SaveChangesAsync();
@@ -103,7 +92,7 @@ public class AttachmentServiceTests
         blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Error("storage error")));
 
-        var result = await sut.UploadAsync([attachment], [stream]);
+        var result = await sut.UploadAsync([(attachment, (Stream)stream)]);
 
         result.Status.Should().Be(ResultStatus.Error);
         await attachmentRepository.DidNotReceive()
@@ -177,7 +166,7 @@ public class AttachmentServiceTests
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeEmpty();
-        await blobStorageService.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await blobDeletionQueue.DidNotReceive().EnqueueDeleteAsync(Arg.Any<Guid>());
         await attachmentRepository.DidNotReceive().DeleteRangeAsync(Arg.Any<IReadOnlyCollection<Guid>>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
@@ -203,8 +192,8 @@ public class AttachmentServiceTests
             Arg.Is<IReadOnlyCollection<Guid>>(ids =>
                 ids.Contains(expired1.Id) && ids.Contains(expired2.Id)));
         await unitOfWork.Received(1).SaveChangesAsync();
-        await blobStorageService.Received(1).DeleteAsync(expired1.BlobId, Arg.Any<CancellationToken>());
-        await blobStorageService.Received(1).DeleteAsync(expired2.BlobId, Arg.Any<CancellationToken>());
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(expired1.BlobId);
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(expired2.BlobId);
     }
 
     [Test]

--- a/backend/ShuKnow.Application.Tests/Services/AttachmentServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/AttachmentServiceTests.cs
@@ -203,6 +203,8 @@ public class AttachmentServiceTests
             Arg.Is<IReadOnlyCollection<Guid>>(ids =>
                 ids.Contains(expired1.Id) && ids.Contains(expired2.Id)));
         await unitOfWork.Received(1).SaveChangesAsync();
+        await blobStorageService.Received(1).DeleteAsync(expired1.BlobId, Arg.Any<CancellationToken>());
+        await blobStorageService.Received(1).DeleteAsync(expired2.BlobId, Arg.Any<CancellationToken>());
     }
 
     [Test]

--- a/backend/ShuKnow.Application.Tests/Services/AttachmentServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/AttachmentServiceTests.cs
@@ -1,5 +1,6 @@
 using Ardalis.Result;
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Application.Services;
@@ -14,6 +15,7 @@ public class AttachmentServiceTests
     private IBlobStorageService blobStorageService = null!;
     private ICurrentUserService currentUserService = null!;
     private IUnitOfWork unitOfWork = null!;
+    private ILogger<AttachmentService> logger = null!;
     private Guid currentUserId;
     private AttachmentService sut = null!;
 
@@ -24,12 +26,18 @@ public class AttachmentServiceTests
         blobStorageService = Substitute.For<IBlobStorageService>();
         currentUserService = Substitute.For<ICurrentUserService>();
         unitOfWork = Substitute.For<IUnitOfWork>();
+        logger = Substitute.For<ILogger<AttachmentService>>();
         currentUserId = Guid.NewGuid();
 
         currentUserService.UserId.Returns(currentUserId);
         unitOfWork.SaveChangesAsync().Returns(Task.FromResult(Result.Success()));
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Success());
+        blobStorageService.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Success());
 
-        sut = new AttachmentService(attachmentRepository, blobStorageService, currentUserService, unitOfWork);
+        sut = new AttachmentService(
+            attachmentRepository, blobStorageService, currentUserService, unitOfWork, logger);
     }
 
     [Test]
@@ -56,8 +64,6 @@ public class AttachmentServiceTests
         var contents = new[] { stream1, stream2 };
 
         attachmentRepository.AddRangeAsync(attachments).Returns(Success());
-        blobStorageService.SaveAsync(stream1, first.Id, Arg.Any<CancellationToken>()).Returns(Success());
-        blobStorageService.SaveAsync(stream2, second.Id, Arg.Any<CancellationToken>()).Returns(Success());
 
         var result = await sut.UploadAsync(attachments, contents);
 
@@ -65,9 +71,11 @@ public class AttachmentServiceTests
         result.Value.Should().HaveCount(2);
         result.Value.Should().Contain(first);
         result.Value.Should().Contain(second);
+        first.BlobId.Should().NotBe(Guid.Empty);
+        second.BlobId.Should().NotBe(Guid.Empty);
         await attachmentRepository.Received(1).AddRangeAsync(attachments);
-        await blobStorageService.Received(1).SaveAsync(stream1, first.Id, Arg.Any<CancellationToken>());
-        await blobStorageService.Received(1).SaveAsync(stream2, second.Id, Arg.Any<CancellationToken>());
+        await blobStorageService.Received(1).SaveAsync(stream1, first.BlobId, Arg.Any<CancellationToken>());
+        await blobStorageService.Received(1).SaveAsync(stream2, second.BlobId, Arg.Any<CancellationToken>());
         await unitOfWork.Received(1).SaveChangesAsync();
     }
 
@@ -83,8 +91,6 @@ public class AttachmentServiceTests
         var result = await sut.UploadAsync([attachment], [stream]);
 
         result.Status.Should().Be(ResultStatus.Error);
-        await blobStorageService.DidNotReceive()
-            .SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 
@@ -94,14 +100,14 @@ public class AttachmentServiceTests
         var attachment = CreateAttachment();
         using var stream = new MemoryStream([1]);
 
-        attachmentRepository.AddRangeAsync(Arg.Any<IReadOnlyCollection<ChatAttachment>>())
-            .Returns(Success());
-        blobStorageService.SaveAsync(stream, attachment.Id, Arg.Any<CancellationToken>())
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Error("storage error")));
 
         var result = await sut.UploadAsync([attachment], [stream]);
 
         result.Status.Should().Be(ResultStatus.Error);
+        await attachmentRepository.DidNotReceive()
+            .AddRangeAsync(Arg.Any<IReadOnlyCollection<ChatAttachment>>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 
@@ -177,24 +183,22 @@ public class AttachmentServiceTests
     }
 
     [Test]
-    public async Task PurgeExpiredAsync_WhenExpiredExist_ShouldDeleteBlobsAndRecordsThenSave()
+    public async Task PurgeExpiredAsync_WhenExpiredExist_ShouldDeleteRecordsThenSave()
     {
         var expired1 = CreateAttachment();
+        expired1.BlobId = Guid.NewGuid();
         var expired2 = CreateAttachment();
+        expired2.BlobId = Guid.NewGuid();
         IReadOnlyList<ChatAttachment> expired = [expired1, expired2];
 
         attachmentRepository.GetExpiredUnconsumedAsync(Arg.Any<DateTimeOffset>())
             .Returns(Task.FromResult(Result.Success(expired)));
-        blobStorageService.DeleteAsync(expired1.Id, Arg.Any<CancellationToken>()).Returns(Success());
-        blobStorageService.DeleteAsync(expired2.Id, Arg.Any<CancellationToken>()).Returns(Success());
         attachmentRepository.DeleteRangeAsync(Arg.Any<IReadOnlyCollection<Guid>>()).Returns(Success());
 
         var result = await sut.PurgeExpiredAsync();
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().HaveCount(2);
-        await blobStorageService.Received(1).DeleteAsync(expired1.Id, Arg.Any<CancellationToken>());
-        await blobStorageService.Received(1).DeleteAsync(expired2.Id, Arg.Any<CancellationToken>());
         await attachmentRepository.Received(1).DeleteRangeAsync(
             Arg.Is<IReadOnlyCollection<Guid>>(ids =>
                 ids.Contains(expired1.Id) && ids.Contains(expired2.Id)));
@@ -202,20 +206,20 @@ public class AttachmentServiceTests
     }
 
     [Test]
-    public async Task PurgeExpiredAsync_WhenBlobDeleteFails_ShouldReturnFailureWithoutSaving()
+    public async Task PurgeExpiredAsync_WhenDeleteRangeFails_ShouldReturnFailureWithoutSaving()
     {
         var expired = CreateAttachment();
+        expired.BlobId = Guid.NewGuid();
         IReadOnlyList<ChatAttachment> expiredList = [expired];
 
         attachmentRepository.GetExpiredUnconsumedAsync(Arg.Any<DateTimeOffset>())
             .Returns(Task.FromResult(Result.Success(expiredList)));
-        blobStorageService.DeleteAsync(expired.Id, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Result.Error("storage error")));
+        attachmentRepository.DeleteRangeAsync(Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(Task.FromResult(Result.Error("db error")));
 
         var result = await sut.PurgeExpiredAsync();
 
         result.Status.Should().Be(ResultStatus.Error);
-        await attachmentRepository.DidNotReceive().DeleteRangeAsync(Arg.Any<IReadOnlyCollection<Guid>>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 

--- a/backend/ShuKnow.Application.Tests/Services/FileServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/FileServiceTests.cs
@@ -185,6 +185,20 @@ public class FileServiceTests
     }
 
     [Test]
+    public async Task DeleteAsync_WhenCommitSucceeds_ShouldDeleteBlobBestEffort()
+    {
+        var file = CreateFile();
+        file.BlobId = Guid.NewGuid();
+        ReturnsExistingFile(file);
+        fileRepository.DeleteAsync(file.Id).Returns(Success());
+
+        var result = await sut.DeleteAsync(file.Id);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await blobStorageService.Received(1).DeleteAsync(file.BlobId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task GetContentAsync_WhenNoRangeIsRequested_ShouldReturnFullContent()
     {
         var file = CreateFile(sizeBytes: 12, contentType: "text/plain");
@@ -278,6 +292,24 @@ public class FileServiceTests
     }
 
     [Test]
+    public async Task ReplaceContentAsync_WhenCommitSucceeds_ShouldDeletePreviousBlobBestEffort()
+    {
+        var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 3, version: 2);
+        var originalBlobId = Guid.NewGuid();
+        existingFile.BlobId = originalBlobId;
+        using var content = CreateStream("updated payload");
+
+        ReturnsExistingFileForUpdate(existingFile);
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Success());
+
+        var result = await sut.ReplaceContentAsync(existingFile.Id, content, "application/json");
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await blobStorageService.Received(1).DeleteAsync(originalBlobId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task MoveAsync_WhenTargetFolderDoesNotExist_ShouldReturnNotFound()
     {
         var fileId = Guid.NewGuid();
@@ -365,6 +397,8 @@ public class FileServiceTests
 
         result.Status.Should().Be(ResultStatus.Ok);
         await unitOfWork.Received(1).SaveChangesAsync();
+        await blobStorageService.Received(1).DeleteAsync(firstFile.BlobId, Arg.Any<CancellationToken>());
+        await blobStorageService.Received(1).DeleteAsync(secondFile.BlobId, Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -511,6 +545,23 @@ public class FileServiceTests
         existingFile.BlobId.Should().NotBe(Guid.Empty);
         uploadedBytes.Should().Equal(expectedBytes);
         await unitOfWork.Received(1).SaveChangesAsync();
+    }
+
+    [Test]
+    public async Task UpdateTextContentAsync_WhenCommitSucceeds_ShouldDeletePreviousBlobBestEffort()
+    {
+        var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 5, version: 1);
+        var originalBlobId = Guid.NewGuid();
+        existingFile.BlobId = originalBlobId;
+
+        ReturnsExistingFileForUpdate(existingFile);
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Success());
+
+        var result = await sut.UpdateTextContentAsync(existingFile.Id, "updated text content");
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await blobStorageService.Received(1).DeleteAsync(originalBlobId, Arg.Any<CancellationToken>());
     }
 
     private void ConfigureDefaults()

--- a/backend/ShuKnow.Application.Tests/Services/FileServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/FileServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Ardalis.Result;
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Application.Services;
@@ -17,6 +18,7 @@ public class FileServiceTests
     private IBlobStorageService blobStorageService = null!;
     private ICurrentUserService currentUserService = null!;
     private IUnitOfWork unitOfWork = null!;
+    private ILogger<FileService> logger = null!;
     private Guid currentUserId;
     private FileService sut = null!;
 
@@ -28,6 +30,7 @@ public class FileServiceTests
         blobStorageService = Substitute.For<IBlobStorageService>();
         currentUserService = Substitute.For<ICurrentUserService>();
         unitOfWork = Substitute.For<IUnitOfWork>();
+        logger = Substitute.For<ILogger<FileService>>();
         currentUserId = Guid.NewGuid();
 
         currentUserService.UserId.Returns(currentUserId);
@@ -38,7 +41,8 @@ public class FileServiceTests
             folderRepository,
             blobStorageService,
             currentUserService,
-            unitOfWork);
+            unitOfWork,
+            logger);
     }
 
     [Test]
@@ -109,14 +113,15 @@ public class FileServiceTests
         ReturnsFolderExists(file.FolderId);
         ReturnsFileNameAvailable(file.Name, file.FolderId, file.Id);
         fileRepository.AddAsync(file).Returns(Success());
-        blobStorageService.SaveAsync(content, file, Arg.Any<CancellationToken>()).Returns(Success());
+        blobStorageService.SaveAsync(content, Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Success());
 
         var result = await sut.UploadAsync(file, content);
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeSameAs(file);
+        file.BlobId.Should().NotBe(Guid.Empty);
         await fileRepository.Received(1).AddAsync(file);
-        await blobStorageService.Received(1).SaveAsync(content, file, Arg.Any<CancellationToken>());
+        await blobStorageService.Received(1).SaveAsync(content, file.BlobId, Arg.Any<CancellationToken>());
         await unitOfWork.Received(1).SaveChangesAsync();
     }
 
@@ -165,18 +170,17 @@ public class FileServiceTests
     }
 
     [Test]
-    public async Task DeleteAsync_WhenFileExists_ShouldDeleteMetadataAndBlob()
+    public async Task DeleteAsync_WhenFileExists_ShouldDeleteMetadataAndCommit()
     {
         var file = CreateFile();
+        file.BlobId = Guid.NewGuid();
         ReturnsExistingFile(file);
         fileRepository.DeleteAsync(file.Id).Returns(Success());
-        blobStorageService.DeleteAsync(file.Id, Arg.Any<CancellationToken>()).Returns(Success());
 
         var result = await sut.DeleteAsync(file.Id);
 
         result.Status.Should().Be(ResultStatus.Ok);
         await fileRepository.Received(1).DeleteAsync(file.Id);
-        await blobStorageService.Received(1).DeleteAsync(file.Id, Arg.Any<CancellationToken>());
         await unitOfWork.Received(1).SaveChangesAsync();
     }
 
@@ -184,9 +188,10 @@ public class FileServiceTests
     public async Task GetContentAsync_WhenNoRangeIsRequested_ShouldReturnFullContent()
     {
         var file = CreateFile(sizeBytes: 12, contentType: "text/plain");
+        file.BlobId = Guid.NewGuid();
         using var stream = CreateStream("full content");
         ReturnsExistingFile(file);
-        blobStorageService.GetAsync(file.Id, Arg.Any<CancellationToken>()).Returns(Success<Stream>(stream));
+        blobStorageService.GetAsync(file.BlobId, Arg.Any<CancellationToken>()).Returns(Success<Stream>(stream));
 
         var result = await sut.GetContentAsync(file.Id);
 
@@ -194,7 +199,7 @@ public class FileServiceTests
         result.Value.Content.Should().BeSameAs(stream);
         result.Value.ContentType.Should().Be(file.ContentType);
         result.Value.SizeBytes.Should().Be(file.SizeBytes);
-        await blobStorageService.Received(1).GetAsync(file.Id, Arg.Any<CancellationToken>());
+        await blobStorageService.Received(1).GetAsync(file.BlobId, Arg.Any<CancellationToken>());
         await blobStorageService.DidNotReceive()
             .GetRangeAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
@@ -203,11 +208,12 @@ public class FileServiceTests
     public async Task GetContentAsync_WhenPartialRangeIsRequested_ShouldRequestBlobRange()
     {
         var file = CreateFile(sizeBytes: 512, contentType: "application/pdf");
+        file.BlobId = Guid.NewGuid();
         using var stream = CreateStream("range");
         const long rangeStart = 128;
 
         ReturnsExistingFile(file);
-        blobStorageService.GetRangeAsync(file.Id, rangeStart, file.SizeBytes, Arg.Any<CancellationToken>())
+        blobStorageService.GetRangeAsync(file.BlobId, rangeStart, file.SizeBytes, Arg.Any<CancellationToken>())
             .Returns(Success<Stream>(stream));
 
         var result = await sut.GetContentAsync(file.Id, rangeStart);
@@ -215,7 +221,7 @@ public class FileServiceTests
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Content.Should().BeSameAs(stream);
         await blobStorageService.Received(1)
-            .GetRangeAsync(file.Id, rangeStart, file.SizeBytes, Arg.Any<CancellationToken>());
+            .GetRangeAsync(file.BlobId, rangeStart, file.SizeBytes, Arg.Any<CancellationToken>());
         await blobStorageService.DidNotReceive().GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
@@ -230,14 +236,16 @@ public class FileServiceTests
 
         result.Status.Should().Be(ResultStatus.NotFound);
         await blobStorageService.DidNotReceive()
-            .ReplaceAsync(Arg.Any<Stream>(), Arg.Any<File>(), Arg.Any<CancellationToken>());
+            .SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 
     [Test]
-    public async Task ReplaceContentAsync_WhenRequestIsValid_ShouldReplaceBlobAndUpdateFileMetadata()
+    public async Task ReplaceContentAsync_WhenRequestIsValid_ShouldSaveNewBlobAndUpdateFileMetadata()
     {
         var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 3, version: 2);
+        var originalBlobId = Guid.NewGuid();
+        existingFile.BlobId = originalBlobId;
         using var content = CreateStream("updated payload");
         var expectedBytes = "updated payload"u8.ToArray();
         byte[]? uploadedBytes = null;
@@ -245,14 +253,14 @@ public class FileServiceTests
 
         ReturnsExistingFileForUpdate(existingFile);
         blobStorageService
-            .ReplaceAsync(Arg.Do<Stream>(stream =>
+            .SaveAsync(Arg.Do<Stream>(stream =>
             {
                 uploadedPosition = stream.Position;
                 using var copy = new MemoryStream();
                 stream.CopyTo(copy);
                 uploadedBytes = copy.ToArray();
                 stream.Position = 0;
-            }), existingFile, Arg.Any<CancellationToken>())
+            }), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Success());
 
         var result = await sut.ReplaceContentAsync(existingFile.Id, content, "application/json");
@@ -262,6 +270,8 @@ public class FileServiceTests
         existingFile.ContentType.Should().Be("application/json");
         existingFile.SizeBytes.Should().Be(expectedBytes.Length);
         existingFile.Version.Should().Be(3);
+        existingFile.BlobId.Should().NotBe(originalBlobId);
+        existingFile.BlobId.Should().NotBe(Guid.Empty);
         uploadedPosition.Should().Be(0);
         uploadedBytes.Should().Equal(expectedBytes);
         await unitOfWork.Received(1).SaveChangesAsync();
@@ -320,24 +330,22 @@ public class FileServiceTests
     }
 
     [Test]
-    public async Task DeleteByFolderAsync_WhenBlobDeletionFails_ShouldReturnFailureWithoutSavingChanges()
+    public async Task DeleteByFolderAsync_WhenFolderHasFiles_ShouldDeleteRecordsAndCommit()
     {
         var folderId = Guid.NewGuid();
         var firstFile = CreateFile(folderId: folderId);
+        firstFile.BlobId = Guid.NewGuid();
         var secondFile = CreateFile(folderId: folderId);
+        secondFile.BlobId = Guid.NewGuid();
 
         ReturnsFolderExists(folderId);
         fileRepository.DeleteByFolderAsync(folderId)
             .Returns(Success<IReadOnlyList<File>>([firstFile, secondFile]));
-        blobStorageService.DeleteAsync(firstFile.Id, Arg.Any<CancellationToken>()).Returns(Success());
-        blobStorageService.DeleteAsync(secondFile.Id, Arg.Any<CancellationToken>()).Returns(Conflict());
 
         var result = await sut.DeleteByFolderAsync(folderId);
 
-        result.Status.Should().Be(ResultStatus.Conflict);
-        await blobStorageService.Received(1).DeleteAsync(firstFile.Id, Arg.Any<CancellationToken>());
-        await blobStorageService.Received(1).DeleteAsync(secondFile.Id, Arg.Any<CancellationToken>());
-        await unitOfWork.DidNotReceive().SaveChangesAsync();
+        result.Status.Should().Be(ResultStatus.Ok);
+        await unitOfWork.Received(1).SaveChangesAsync();
     }
 
     [Test]
@@ -345,19 +353,17 @@ public class FileServiceTests
     {
         var folderId = Guid.NewGuid();
         var firstFile = CreateFile(folderId: folderId);
+        firstFile.BlobId = Guid.NewGuid();
         var secondFile = CreateFile(folderId: folderId);
+        secondFile.BlobId = Guid.NewGuid();
 
         ReturnsFolderExists(folderId);
         fileRepository.DeleteByFolderAsync(folderId)
             .Returns(Success<IReadOnlyList<File>>([firstFile, secondFile]));
-        blobStorageService.DeleteAsync(firstFile.Id, Arg.Any<CancellationToken>()).Returns(Success());
-        blobStorageService.DeleteAsync(secondFile.Id, Arg.Any<CancellationToken>()).Returns(Success());
 
         var result = await sut.DeleteByFolderAsync(folderId);
 
         result.Status.Should().Be(ResultStatus.Ok);
-        await blobStorageService.Received(1).DeleteAsync(firstFile.Id, Arg.Any<CancellationToken>());
-        await blobStorageService.Received(1).DeleteAsync(secondFile.Id, Arg.Any<CancellationToken>());
         await unitOfWork.Received(1).SaveChangesAsync();
     }
 
@@ -455,7 +461,7 @@ public class FileServiceTests
 
         result.Status.Should().Be(ResultStatus.NotFound);
         await blobStorageService.DidNotReceive()
-            .ReplaceAsync(Arg.Any<Stream>(), Arg.Any<File>(), Arg.Any<CancellationToken>());
+            .SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 
@@ -469,27 +475,29 @@ public class FileServiceTests
 
         result.Status.Should().Be(ResultStatus.Invalid);
         await blobStorageService.DidNotReceive()
-            .ReplaceAsync(Arg.Any<Stream>(), Arg.Any<File>(), Arg.Any<CancellationToken>());
+            .SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 
     [Test]
-    public async Task UpdateTextContentAsync_WhenRequestIsValid_ShouldReplaceContentAndUpdateSize()
+    public async Task UpdateTextContentAsync_WhenRequestIsValid_ShouldSaveNewBlobAndUpdateSize()
     {
         var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 5, version: 1);
+        var originalBlobId = Guid.NewGuid();
+        existingFile.BlobId = originalBlobId;
         const string newContent = "updated text content";
         var expectedBytes = Encoding.UTF8.GetBytes(newContent);
         byte[]? uploadedBytes = null;
 
         ReturnsExistingFileForUpdate(existingFile);
         blobStorageService
-            .ReplaceAsync(Arg.Do<Stream>(stream =>
+            .SaveAsync(Arg.Do<Stream>(stream =>
             {
                 using var copy = new MemoryStream();
                 stream.CopyTo(copy);
                 uploadedBytes = copy.ToArray();
                 stream.Position = 0;
-            }), existingFile, Arg.Any<CancellationToken>())
+            }), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Success());
 
         var result = await sut.UpdateTextContentAsync(existingFile.Id, newContent);
@@ -499,6 +507,8 @@ public class FileServiceTests
         existingFile.ContentType.Should().Be("text/plain");
         existingFile.SizeBytes.Should().Be(expectedBytes.Length);
         existingFile.Version.Should().Be(2);
+        existingFile.BlobId.Should().NotBe(originalBlobId);
+        existingFile.BlobId.Should().NotBe(Guid.Empty);
         uploadedBytes.Should().Equal(expectedBytes);
         await unitOfWork.Received(1).SaveChangesAsync();
     }
@@ -515,9 +525,7 @@ public class FileServiceTests
         fileRepository.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<Guid>()).Returns(NotFound<File>());
         fileRepository.GetByIdForUpdateAsync(Arg.Any<Guid>(), Arg.Any<Guid>()).Returns(NotFound<File>());
         fileRepository.GetByFolderAsync(Arg.Any<Guid>()).Returns(Success<IReadOnlyList<File>>([]));
-        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<File>(), Arg.Any<CancellationToken>())
-            .Returns(Success());
-        blobStorageService.ReplaceAsync(Arg.Any<Stream>(), Arg.Any<File>(), Arg.Any<CancellationToken>())
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Success());
         blobStorageService.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Success());
         blobStorageService.GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
@@ -558,7 +566,7 @@ public class FileServiceTests
     {
         await fileRepository.DidNotReceive().AddAsync(Arg.Any<File>());
         await blobStorageService.DidNotReceive()
-            .SaveAsync(Arg.Any<Stream>(), Arg.Any<File>(), Arg.Any<CancellationToken>());
+            .SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await unitOfWork.DidNotReceive().SaveChangesAsync();
     }
 

--- a/backend/ShuKnow.Application.Tests/Services/FileServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/FileServiceTests.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using Ardalis.Result;
 using AwesomeAssertions;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Application.Services;
@@ -16,9 +15,9 @@ public class FileServiceTests
     private IFileRepository fileRepository = null!;
     private IFolderRepository folderRepository = null!;
     private IBlobStorageService blobStorageService = null!;
+    private IBlobDeletionQueue blobDeletionQueue = null!;
     private ICurrentUserService currentUserService = null!;
     private IUnitOfWork unitOfWork = null!;
-    private ILogger<FileService> logger = null!;
     private Guid currentUserId;
     private FileService sut = null!;
 
@@ -28,9 +27,9 @@ public class FileServiceTests
         fileRepository = Substitute.For<IFileRepository>();
         folderRepository = Substitute.For<IFolderRepository>();
         blobStorageService = Substitute.For<IBlobStorageService>();
+        blobDeletionQueue = Substitute.For<IBlobDeletionQueue>();
         currentUserService = Substitute.For<ICurrentUserService>();
         unitOfWork = Substitute.For<IUnitOfWork>();
-        logger = Substitute.For<ILogger<FileService>>();
         currentUserId = Guid.NewGuid();
 
         currentUserService.UserId.Returns(currentUserId);
@@ -40,9 +39,9 @@ public class FileServiceTests
             fileRepository,
             folderRepository,
             blobStorageService,
+            blobDeletionQueue,
             currentUserService,
-            unitOfWork,
-            logger);
+            unitOfWork);
     }
 
     [Test]
@@ -195,7 +194,7 @@ public class FileServiceTests
         var result = await sut.DeleteAsync(file.Id);
 
         result.Status.Should().Be(ResultStatus.Ok);
-        await blobStorageService.Received(1).DeleteAsync(file.BlobId, Arg.Any<CancellationToken>());
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(file.BlobId);
     }
 
     [Test]
@@ -306,7 +305,49 @@ public class FileServiceTests
         var result = await sut.ReplaceContentAsync(existingFile.Id, content, "application/json");
 
         result.Status.Should().Be(ResultStatus.Ok);
-        await blobStorageService.Received(1).DeleteAsync(originalBlobId, Arg.Any<CancellationToken>());
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(originalBlobId);
+    }
+
+    [Test]
+    public async Task ReplaceContentAsync_WhenBlobSaveFails_ShouldNotMutateTrackedFile()
+    {
+        var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 3, version: 2);
+        var originalBlobId = Guid.NewGuid();
+        existingFile.BlobId = originalBlobId;
+        using var content = CreateStream("updated payload");
+
+        ReturnsExistingFileForUpdate(existingFile);
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Error("storage error")));
+
+        var result = await sut.ReplaceContentAsync(existingFile.Id, content, "application/json");
+
+        result.Status.Should().Be(ResultStatus.Error);
+        existingFile.ContentType.Should().Be("text/plain");
+        existingFile.SizeBytes.Should().Be(3);
+        existingFile.Version.Should().Be(2);
+        existingFile.BlobId.Should().Be(originalBlobId);
+        await unitOfWork.DidNotReceive().SaveChangesAsync();
+        await blobDeletionQueue.DidNotReceive().EnqueueDeleteAsync(Arg.Any<Guid>());
+    }
+
+    [Test]
+    public async Task ReplaceContentAsync_WhenInputIsSeekable_ShouldUploadOriginalStreamWithoutBuffering()
+    {
+        var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 3, version: 2);
+        existingFile.BlobId = Guid.NewGuid();
+        using var content = CreateStream("updated payload");
+        content.Position = 8;
+
+        ReturnsExistingFileForUpdate(existingFile);
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Success());
+
+        var result = await sut.ReplaceContentAsync(existingFile.Id, content, "application/json");
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        existingFile.SizeBytes.Should().Be(content.Length - 8);
+        await blobStorageService.Received(1).SaveAsync(content, Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -397,8 +438,8 @@ public class FileServiceTests
 
         result.Status.Should().Be(ResultStatus.Ok);
         await unitOfWork.Received(1).SaveChangesAsync();
-        await blobStorageService.Received(1).DeleteAsync(firstFile.BlobId, Arg.Any<CancellationToken>());
-        await blobStorageService.Received(1).DeleteAsync(secondFile.BlobId, Arg.Any<CancellationToken>());
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(firstFile.BlobId);
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(secondFile.BlobId);
     }
 
     [Test]
@@ -561,7 +602,29 @@ public class FileServiceTests
         var result = await sut.UpdateTextContentAsync(existingFile.Id, "updated text content");
 
         result.Status.Should().Be(ResultStatus.Ok);
-        await blobStorageService.Received(1).DeleteAsync(originalBlobId, Arg.Any<CancellationToken>());
+        await blobDeletionQueue.Received(1).EnqueueDeleteAsync(originalBlobId);
+    }
+
+    [Test]
+    public async Task UpdateTextContentAsync_WhenBlobSaveFails_ShouldNotMutateTrackedFile()
+    {
+        var existingFile = CreateFile(contentType: "text/plain", sizeBytes: 5, version: 1);
+        var originalBlobId = Guid.NewGuid();
+        existingFile.BlobId = originalBlobId;
+
+        ReturnsExistingFileForUpdate(existingFile);
+        blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Error("storage error")));
+
+        var result = await sut.UpdateTextContentAsync(existingFile.Id, "updated text content");
+
+        result.Status.Should().Be(ResultStatus.Error);
+        existingFile.ContentType.Should().Be("text/plain");
+        existingFile.SizeBytes.Should().Be(5);
+        existingFile.Version.Should().Be(1);
+        existingFile.BlobId.Should().Be(originalBlobId);
+        await unitOfWork.DidNotReceive().SaveChangesAsync();
+        await blobDeletionQueue.DidNotReceive().EnqueueDeleteAsync(Arg.Any<Guid>());
     }
 
     private void ConfigureDefaults()
@@ -578,7 +641,7 @@ public class FileServiceTests
         fileRepository.GetByFolderAsync(Arg.Any<Guid>()).Returns(Success<IReadOnlyList<File>>([]));
         blobStorageService.SaveAsync(Arg.Any<Stream>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Success());
-        blobStorageService.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Success());
+        blobDeletionQueue.EnqueueDeleteAsync(Arg.Any<Guid>()).Returns(ValueTask.CompletedTask);
         blobStorageService.GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(_ => Success<Stream>(new MemoryStream()));
         blobStorageService

--- a/backend/ShuKnow.Application/Common/BlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/BlobStorageOptions.cs
@@ -1,0 +1,27 @@
+namespace ShuKnow.Application.Common;
+
+public class BlobStorageOptions
+{
+    public const string SectionName = "BlobStorage";
+    public const string FileSystemProvider = "FileSystem";
+    public const string S3Provider = "S3";
+
+    public string Provider { get; set; } = "";
+
+    public bool UsesFileSystem =>
+        string.Equals(Provider, FileSystemProvider, StringComparison.OrdinalIgnoreCase);
+
+    public bool UsesS3 =>
+        string.Equals(Provider, S3Provider, StringComparison.OrdinalIgnoreCase);
+
+    public BlobStorageOptions Validate()
+    {
+        Provider = Provider.Trim();
+
+        if (UsesFileSystem || UsesS3)
+            return this;
+
+        throw new InvalidOperationException(
+            $"{SectionName}:Provider must be '{FileSystemProvider}' or '{S3Provider}', got '{Provider}'.");
+    }
+}

--- a/backend/ShuKnow.Application/Common/BlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/BlobStorageOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ShuKnow.Application.Common;
 
 public class BlobStorageOptions
@@ -6,6 +8,7 @@ public class BlobStorageOptions
     public const string FileSystemProvider = "FileSystem";
     public const string S3Provider = "S3";
 
+    [Required(AllowEmptyStrings = false)]
     public string Provider { get; set; } = "";
 
     public bool UsesFileSystem =>
@@ -13,13 +16,4 @@ public class BlobStorageOptions
 
     public bool UsesS3 =>
         string.Equals(Provider, S3Provider, StringComparison.OrdinalIgnoreCase);
-
-    public BlobStorageOptions Validate()
-    {
-        if (UsesFileSystem || UsesS3)
-            return this;
-
-        throw new InvalidOperationException(
-            $"{SectionName}:Provider must be '{FileSystemProvider}' or '{S3Provider}', got '{Provider}'.");
-    }
 }

--- a/backend/ShuKnow.Application/Common/BlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/BlobStorageOptions.cs
@@ -16,8 +16,6 @@ public class BlobStorageOptions
 
     public BlobStorageOptions Validate()
     {
-        Provider = Provider.Trim();
-
         if (UsesFileSystem || UsesS3)
             return this;
 

--- a/backend/ShuKnow.Application/Common/EncryptionOptions.cs
+++ b/backend/ShuKnow.Application/Common/EncryptionOptions.cs
@@ -1,16 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ShuKnow.Application.Common;
 
 public class EncryptionOptions
 {
     public const string SectionName = "Encryption";
-
+    
+    [Required(AllowEmptyStrings = false)]
     public string Key { get; set; } = "";
-
-    public EncryptionOptions Validate()
-    {
-        if (string.IsNullOrEmpty(Key))
-            throw new InvalidOperationException($"{SectionName}:Key is not configured");
-
-        return this;
-    }
 }

--- a/backend/ShuKnow.Application/Common/FileSystemBlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/FileSystemBlobStorageOptions.cs
@@ -1,0 +1,18 @@
+namespace ShuKnow.Application.Common;
+
+public class FileSystemBlobStorageOptions
+{
+    public const string SectionName = "BlobStorage:FileSystem";
+
+    public string BasePath { get; set; } = "";
+
+    public FileSystemBlobStorageOptions Validate()
+    {
+        BasePath = BasePath.Trim();
+
+        if (string.IsNullOrEmpty(BasePath))
+            throw new InvalidOperationException($"{SectionName}:BasePath is not configured");
+
+        return this;
+    }
+}

--- a/backend/ShuKnow.Application/Common/FileSystemBlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/FileSystemBlobStorageOptions.cs
@@ -1,16 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ShuKnow.Application.Common;
 
 public class FileSystemBlobStorageOptions
 {
     public const string SectionName = "BlobStorage:FileSystem";
 
+    [Required(AllowEmptyStrings = false)]
     public string BasePath { get; set; } = "";
-
-    public FileSystemBlobStorageOptions Validate()
-    {
-        if (string.IsNullOrEmpty(BasePath))
-            throw new InvalidOperationException($"{SectionName}:BasePath is not configured");
-
-        return this;
-    }
 }

--- a/backend/ShuKnow.Application/Common/FileSystemBlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/FileSystemBlobStorageOptions.cs
@@ -8,8 +8,6 @@ public class FileSystemBlobStorageOptions
 
     public FileSystemBlobStorageOptions Validate()
     {
-        BasePath = BasePath.Trim();
-
         if (string.IsNullOrEmpty(BasePath))
             throw new InvalidOperationException($"{SectionName}:BasePath is not configured");
 

--- a/backend/ShuKnow.Application/Common/JwtOptions.cs
+++ b/backend/ShuKnow.Application/Common/JwtOptions.cs
@@ -1,25 +1,20 @@
-﻿namespace ShuKnow.Application.Common;
+using System.ComponentModel.DataAnnotations;
+
+namespace ShuKnow.Application.Common;
 
 public class JwtOptions
 {
     public const string SectionName = "Jwt";
-    
+
+    [Required(AllowEmptyStrings = false)]
     public string Key { get; set; } = "";
+
+    [Range(1, int.MaxValue)]
     public int ExpiresInMinutes { get; set; } = 60;
+
+    [Required(AllowEmptyStrings = false)]
     public string Issuer { get; set; } = "";
+
+    [Required(AllowEmptyStrings = false)]
     public string Audience { get; set; } = "";
-
-    public JwtOptions Validate()
-    {
-        if (string.IsNullOrEmpty(Key))
-            throw new InvalidOperationException($"{SectionName}:Key is not configured");
-        
-        if (string.IsNullOrEmpty(Issuer))
-            throw new InvalidOperationException($"{SectionName}:Issuer is not configured");
-        
-        if (string.IsNullOrEmpty(Audience))
-            throw new InvalidOperationException($"{SectionName}:Audience is not configured");
-
-        return this;
-    }
 }

--- a/backend/ShuKnow.Application/Common/OrphanCleanupOptions.cs
+++ b/backend/ShuKnow.Application/Common/OrphanCleanupOptions.cs
@@ -1,27 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ShuKnow.Application.Common;
 
 public class OrphanCleanupOptions
 {
     public const string SectionName = "BlobStorage:OrphanCleanup";
-
+    
+    [Range(0, double.MaxValue, MinimumIsExclusive = true)]
     public double IntervalHours { get; set; } = 6;
-
+    
+    [Range(0, double.MaxValue, MinimumIsExclusive = true)]
     public double GracePeriodMinutes { get; set; } = 60;
-
-    public OrphanCleanupOptions Validate()
-    {
-        if (IntervalHours <= 0)
-            throw new InvalidOperationException(
-                $"{SectionName}:IntervalHours must be positive, got {IntervalHours}");
-
-        if (GracePeriodMinutes <= 0)
-            throw new InvalidOperationException(
-                $"{SectionName}:GracePeriodMinutes must be positive, got {GracePeriodMinutes}");
-
-        if (GracePeriodMinutes > IntervalHours * 60)
-            throw new InvalidOperationException(
-                $"{SectionName}:GracePeriodMinutes must be less, than {SectionName}:IntervalHours hours, got {GracePeriodMinutes} minutes > {IntervalHours} hours");
-
-        return this;
-    }
 }

--- a/backend/ShuKnow.Application/Common/OrphanCleanupOptions.cs
+++ b/backend/ShuKnow.Application/Common/OrphanCleanupOptions.cs
@@ -1,0 +1,23 @@
+namespace ShuKnow.Application.Common;
+
+public class OrphanCleanupOptions
+{
+    public const string SectionName = "BlobStorage:OrphanCleanup";
+
+    public double IntervalHours { get; set; } = 6;
+
+    public double GracePeriodMinutes { get; set; } = 60;
+
+    public OrphanCleanupOptions Validate()
+    {
+        if (IntervalHours <= 0)
+            throw new InvalidOperationException(
+                $"{SectionName}:IntervalHours must be positive, got {IntervalHours}");
+
+        if (GracePeriodMinutes <= 0)
+            throw new InvalidOperationException(
+                $"{SectionName}:GracePeriodMinutes must be positive, got {GracePeriodMinutes}");
+
+        return this;
+    }
+}

--- a/backend/ShuKnow.Application/Common/OrphanCleanupOptions.cs
+++ b/backend/ShuKnow.Application/Common/OrphanCleanupOptions.cs
@@ -18,6 +18,10 @@ public class OrphanCleanupOptions
             throw new InvalidOperationException(
                 $"{SectionName}:GracePeriodMinutes must be positive, got {GracePeriodMinutes}");
 
+        if (GracePeriodMinutes > IntervalHours * 60)
+            throw new InvalidOperationException(
+                $"{SectionName}:GracePeriodMinutes must be less, than {SectionName}:IntervalHours hours, got {GracePeriodMinutes} minutes > {IntervalHours} hours");
+
         return this;
     }
 }

--- a/backend/ShuKnow.Application/Common/S3BlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/S3BlobStorageOptions.cs
@@ -1,30 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ShuKnow.Application.Common;
 
 public class S3BlobStorageOptions
 {
     public const string SectionName = "BlobStorage:S3";
     
+    [Required(AllowEmptyStrings = false)]
     public string ServiceUrl { get; set; } = "";
+    
+    [Required(AllowEmptyStrings = false)]
     public string AccessKey { get; set; } = "";
+    
+    [Required(AllowEmptyStrings = false)]
     public string SecretKey { get; set; } = "";
+    
+    [Required(AllowEmptyStrings = false)]
     public string BucketName { get; set; } = "";
+    
     public string Prefix { get; set; } = "";
+    
     public bool ForcePathStyle { get; set; } = true;
-
-    public S3BlobStorageOptions Validate()
-    {
-        if (string.IsNullOrEmpty(ServiceUrl))
-            throw new InvalidOperationException($"{SectionName}:ServiceUrl is not configured");
-
-        if (string.IsNullOrEmpty(AccessKey))
-            throw new InvalidOperationException($"{SectionName}:AccessKey is not configured");
-
-        if (string.IsNullOrEmpty(SecretKey))
-            throw new InvalidOperationException($"{SectionName}:SecretKey is not configured");
-
-        if (string.IsNullOrEmpty(BucketName))
-            throw new InvalidOperationException($"{SectionName}:BucketName is not configured");
-
-        return this;
-    }
 }

--- a/backend/ShuKnow.Application/Common/S3BlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/S3BlobStorageOptions.cs
@@ -3,7 +3,7 @@ namespace ShuKnow.Application.Common;
 public class S3BlobStorageOptions
 {
     public const string SectionName = "BlobStorage:S3";
-
+    
     public string ServiceUrl { get; set; } = "";
     public string AccessKey { get; set; } = "";
     public string SecretKey { get; set; } = "";
@@ -13,12 +13,6 @@ public class S3BlobStorageOptions
 
     public S3BlobStorageOptions Validate()
     {
-        ServiceUrl = ServiceUrl.Trim();
-        AccessKey = AccessKey.Trim();
-        SecretKey = SecretKey.Trim();
-        BucketName = BucketName.Trim();
-        Prefix = Prefix.Trim().Trim('/');
-
         if (string.IsNullOrEmpty(ServiceUrl))
             throw new InvalidOperationException($"{SectionName}:ServiceUrl is not configured");
 

--- a/backend/ShuKnow.Application/Common/S3BlobStorageOptions.cs
+++ b/backend/ShuKnow.Application/Common/S3BlobStorageOptions.cs
@@ -1,0 +1,36 @@
+namespace ShuKnow.Application.Common;
+
+public class S3BlobStorageOptions
+{
+    public const string SectionName = "BlobStorage:S3";
+
+    public string ServiceUrl { get; set; } = "";
+    public string AccessKey { get; set; } = "";
+    public string SecretKey { get; set; } = "";
+    public string BucketName { get; set; } = "";
+    public string Prefix { get; set; } = "";
+    public bool ForcePathStyle { get; set; } = true;
+
+    public S3BlobStorageOptions Validate()
+    {
+        ServiceUrl = ServiceUrl.Trim();
+        AccessKey = AccessKey.Trim();
+        SecretKey = SecretKey.Trim();
+        BucketName = BucketName.Trim();
+        Prefix = Prefix.Trim().Trim('/');
+
+        if (string.IsNullOrEmpty(ServiceUrl))
+            throw new InvalidOperationException($"{SectionName}:ServiceUrl is not configured");
+
+        if (string.IsNullOrEmpty(AccessKey))
+            throw new InvalidOperationException($"{SectionName}:AccessKey is not configured");
+
+        if (string.IsNullOrEmpty(SecretKey))
+            throw new InvalidOperationException($"{SectionName}:SecretKey is not configured");
+
+        if (string.IsNullOrEmpty(BucketName))
+            throw new InvalidOperationException($"{SectionName}:BucketName is not configured");
+
+        return this;
+    }
+}

--- a/backend/ShuKnow.Application/Extensions/ResultExtensions.cs
+++ b/backend/ShuKnow.Application/Extensions/ResultExtensions.cs
@@ -21,6 +21,12 @@ public static class ResultExtensions
         return await resultTask.BindAsync(source => Task.FromResult(bindFunc(source)));
     }
 
+    public static async Task<Result<TDestination>> Map<TSource, TDestination>(
+        this Task<Result<TSource>> result, Func<TSource, TDestination> mapFunc)
+    {
+        return (await result).Map(mapFunc);
+    }
+
     public static async Task<Result<TSource>> ActAsync<TSource, TDestination>(
         this Task<Result<TSource>> result, Func<TSource, Task<Result<TDestination>>> actFunc)
     {

--- a/backend/ShuKnow.Application/Interfaces/IAttachmentService.cs
+++ b/backend/ShuKnow.Application/Interfaces/IAttachmentService.cs
@@ -6,8 +6,7 @@ namespace ShuKnow.Application.Interfaces;
 public interface IAttachmentService
 {
     Task<Result<IReadOnlyList<ChatAttachment>>> UploadAsync(
-        IReadOnlyCollection<ChatAttachment> attachments,
-        IReadOnlyCollection<Stream> contents,
+        IReadOnlyList<(ChatAttachment Attachment, Stream Content)> uploads,
         CancellationToken ct = default);
     
     Task<Result<IReadOnlyList<ChatAttachment>>> GetByIdsAsync(

--- a/backend/ShuKnow.Application/Interfaces/IBlobDeletionQueue.cs
+++ b/backend/ShuKnow.Application/Interfaces/IBlobDeletionQueue.cs
@@ -1,0 +1,6 @@
+namespace ShuKnow.Application.Interfaces;
+
+public interface IBlobDeletionQueue
+{
+    ValueTask EnqueueDeleteAsync(Guid blobId);
+}

--- a/backend/ShuKnow.Application/Interfaces/IBlobStorageService.cs
+++ b/backend/ShuKnow.Application/Interfaces/IBlobStorageService.cs
@@ -2,21 +2,15 @@ using Ardalis.Result;
 
 namespace ShuKnow.Application.Interfaces;
 
-using File = Domain.Entities.File;
-
 public interface IBlobStorageService
 {
-    Task<Result> SaveAsync(Stream content, File file, CancellationToken ct = default);
-    
-    Task<Result> SaveAsync(Stream content, Guid id, CancellationToken ct = default);
-    
-    Task<Result> ReplaceAsync(Stream content, File file, CancellationToken ct = default);
-    
-    Task<Result<Stream>> GetAsync(Guid fileId, CancellationToken ct = default);
-    
-    Task<Result<Stream>> GetRangeAsync(Guid fileId, long rangeStart, long rangeEnd, CancellationToken ct = default);
-    
-    Task<Result> DeleteAsync(Guid fileId, CancellationToken ct = default);
-    
-    Task<Result<long>> GetSizeAsync(Guid fileId, CancellationToken ct = default);
+    Task<Result> SaveAsync(Stream content, Guid blobId, CancellationToken ct = default);
+
+    Task<Result<Stream>> GetAsync(Guid blobId, CancellationToken ct = default);
+
+    Task<Result<Stream>> GetRangeAsync(Guid blobId, long rangeStart, long rangeEnd, CancellationToken ct = default);
+
+    Task<Result> DeleteAsync(Guid blobId, CancellationToken ct = default);
+
+    Task<Result<long>> GetSizeAsync(Guid blobId, CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Application/Services/AttachmentService.cs
+++ b/backend/ShuKnow.Application/Services/AttachmentService.cs
@@ -1,5 +1,4 @@
 using Ardalis.Result;
-using Microsoft.Extensions.Logging;
 using ShuKnow.Application.Extensions;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Domain.Entities;
@@ -10,9 +9,9 @@ namespace ShuKnow.Application.Services;
 public class AttachmentService(
     IAttachmentRepository attachmentRepository,
     IBlobStorageService blobStorageService,
+    IBlobDeletionQueue blobDeletionQueue,
     ICurrentUserService currentUserService,
-    IUnitOfWork unitOfWork,
-    ILogger<AttachmentService> logger)
+    IUnitOfWork unitOfWork)
     : IAttachmentService
 {
     private static readonly TimeSpan ExpirationThreshold = TimeSpan.FromHours(1);
@@ -20,18 +19,15 @@ public class AttachmentService(
     private Guid CurrentUserId => currentUserService.UserId;
 
     public async Task<Result<IReadOnlyList<ChatAttachment>>> UploadAsync(
-        IReadOnlyCollection<ChatAttachment> attachments,
-        IReadOnlyCollection<Stream> contents,
+        IReadOnlyList<(ChatAttachment Attachment, Stream Content)> uploads,
         CancellationToken ct = default)
     {
-        if (attachments.Count != contents.Count)
-            return Result<IReadOnlyList<ChatAttachment>>.Invalid(
-                new ValidationError("Attachments and contents counts must match."));
+        var attachments = uploads.Select(upload => upload.Attachment).ToList();
 
         foreach (var attachment in attachments)
             attachment.BlobId = Guid.NewGuid();
 
-        return await SaveBlobsAsync(attachments, contents, ct)
+        return await SaveBlobsAsync(uploads, ct)
             .BindAsync(_ => attachmentRepository.AddRangeAsync(attachments))
             .SaveChangesAsync(unitOfWork)
             .MapAsync(() => (IReadOnlyList<ChatAttachment>)attachments.ToList());
@@ -65,17 +61,15 @@ public class AttachmentService(
                 return await attachmentRepository.DeleteRangeAsync(ids)
                     .SaveChangesAsync(unitOfWork)
                     .MapAsync(() => expired)
-                    .Act(list => DeleteBlobsInBackground(
-                        list.Select(a => a.BlobId).ToList()));
+                    .ActAsync(list => EnqueueDeletesAsync(list.Select(a => a.BlobId)));
             });
     }
 
     private async Task<Result> SaveBlobsAsync(
-        IReadOnlyCollection<ChatAttachment> attachments,
-        IReadOnlyCollection<Stream> contents,
+        IReadOnlyList<(ChatAttachment Attachment, Stream Content)> uploads,
         CancellationToken ct)
     {
-        foreach (var (attachment, content) in attachments.Zip(contents))
+        foreach (var (attachment, content) in uploads)
         {
             var result = await blobStorageService.SaveAsync(content, attachment.BlobId, ct);
             if (!result.IsSuccess)
@@ -85,25 +79,9 @@ public class AttachmentService(
         return Result.Success();
     }
 
-    private void DeleteBlobsInBackground(IReadOnlyList<Guid> blobIds)
+    private async Task EnqueueDeletesAsync(IEnumerable<Guid> blobIds)
     {
         foreach (var blobId in blobIds)
-            _ = DeleteBlobSilently(blobId);
-    }
-
-    private async Task DeleteBlobSilently(Guid blobId)
-    {
-        try
-        {
-            var result = await blobStorageService.DeleteAsync(blobId);
-            if (!result.IsSuccess)
-                logger.LogWarning(
-                    "Best-effort blob cleanup failed for {BlobId}: {Errors}",
-                    blobId, string.Join(", ", result.Errors));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Best-effort blob cleanup failed for {BlobId}", blobId);
-        }
+            await blobDeletionQueue.EnqueueDeleteAsync(blobId);
     }
 }

--- a/backend/ShuKnow.Application/Services/AttachmentService.cs
+++ b/backend/ShuKnow.Application/Services/AttachmentService.cs
@@ -1,4 +1,5 @@
 using Ardalis.Result;
+using Microsoft.Extensions.Logging;
 using ShuKnow.Application.Extensions;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Domain.Entities;
@@ -10,7 +11,8 @@ public class AttachmentService(
     IAttachmentRepository attachmentRepository,
     IBlobStorageService blobStorageService,
     ICurrentUserService currentUserService,
-    IUnitOfWork unitOfWork)
+    IUnitOfWork unitOfWork,
+    ILogger<AttachmentService> logger)
     : IAttachmentService
 {
     private static readonly TimeSpan ExpirationThreshold = TimeSpan.FromHours(1);
@@ -26,8 +28,11 @@ public class AttachmentService(
             return Result<IReadOnlyList<ChatAttachment>>.Invalid(
                 new ValidationError("Attachments and contents counts must match."));
 
-        return await attachmentRepository.AddRangeAsync(attachments)
-            .BindAsync(_ => SaveBlobsAsync(attachments, contents, ct))
+        foreach (var attachment in attachments)
+            attachment.BlobId = Guid.NewGuid();
+
+        return await SaveBlobsAsync(attachments, contents, ct)
+            .BindAsync(_ => attachmentRepository.AddRangeAsync(attachments))
             .SaveChangesAsync(unitOfWork)
             .MapAsync(() => (IReadOnlyList<ChatAttachment>)attachments.ToList());
     }
@@ -56,10 +61,12 @@ public class AttachmentService(
                     return Result.Success(expired);
 
                 var ids = expired.Select(a => a.Id).ToList();
-                return await DeleteBlobsAsync(expired, ct)
-                    .BindAsync(_ => attachmentRepository.DeleteRangeAsync(ids))
+
+                return await attachmentRepository.DeleteRangeAsync(ids)
                     .SaveChangesAsync(unitOfWork)
-                    .MapAsync(() => expired);
+                    .MapAsync(() => expired)
+                    .Act(list => DeleteBlobsInBackground(
+                        list.Select(a => a.BlobId).ToList()));
             });
     }
 
@@ -70,7 +77,7 @@ public class AttachmentService(
     {
         foreach (var (attachment, content) in attachments.Zip(contents))
         {
-            var result = await blobStorageService.SaveAsync(content, attachment.Id, ct);
+            var result = await blobStorageService.SaveAsync(content, attachment.BlobId, ct);
             if (!result.IsSuccess)
                 return result;
         }
@@ -78,17 +85,25 @@ public class AttachmentService(
         return Result.Success();
     }
 
-    private async Task<Result> DeleteBlobsAsync(
-        IReadOnlyList<ChatAttachment> attachments,
-        CancellationToken ct)
+    private void DeleteBlobsInBackground(IReadOnlyList<Guid> blobIds)
     {
-        foreach (var attachment in attachments)
-        {
-            var result = await blobStorageService.DeleteAsync(attachment.Id, ct);
-            if (!result.IsSuccess)
-                return result;
-        }
+        foreach (var blobId in blobIds)
+            _ = DeleteBlobSilently(blobId);
+    }
 
-        return Result.Success();
+    private async Task DeleteBlobSilently(Guid blobId)
+    {
+        try
+        {
+            var result = await blobStorageService.DeleteAsync(blobId);
+            if (!result.IsSuccess)
+                logger.LogWarning(
+                    "Best-effort blob cleanup failed for {BlobId}: {Errors}",
+                    blobId, string.Join(", ", result.Errors));
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Best-effort blob cleanup failed for {BlobId}", blobId);
+        }
     }
 }

--- a/backend/ShuKnow.Application/Services/FileService.cs
+++ b/backend/ShuKnow.Application/Services/FileService.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Ardalis.Result;
+using Microsoft.Extensions.Logging;
 using ShuKnow.Application.Extensions;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Domain.Entities;
@@ -14,7 +15,8 @@ public class FileService(
     IFolderRepository folderRepository,
     IBlobStorageService blobStorageService,
     ICurrentUserService currentUserService,
-    IUnitOfWork unitOfWork)
+    IUnitOfWork unitOfWork,
+    ILogger<FileService> logger)
     : IFileService
 {
     private Guid CurrentUserId => currentUserService.UserId;
@@ -33,10 +35,12 @@ public class FileService(
     public async Task<Result<File>> UploadAsync(
         File file, Stream content, CancellationToken ct = default)
     {
+        file.BlobId = Guid.NewGuid();
+
         return await EnsureFolderExistsAsync(file.FolderId)
             .BindAsync(_ => EnsureFileNameUnique(file.Name, file.FolderId, file.Id))
+            .BindAsync(_ => blobStorageService.SaveAsync(content, file.BlobId, ct))
             .BindAsync(_ => fileRepository.AddAsync(file))
-            .BindAsync(_ => blobStorageService.SaveAsync(content, file, ct))
             .SaveChangesAsync(unitOfWork)
             .MapAsync(() => file);
     }
@@ -52,20 +56,21 @@ public class FileService(
     public async Task<Result> DeleteAsync(Guid fileId, CancellationToken ct = default)
     {
         return await fileRepository.GetByIdAsync(fileId, CurrentUserId)
-            .BindAsync(file => fileRepository.DeleteAsync(file.Id)
-                .BindAsync(_ => blobStorageService.DeleteAsync(file.Id, ct))
-                .SaveChangesAsync(unitOfWork));
+            .ActAsync(file => fileRepository.DeleteAsync(file.Id))
+            .SaveChangesAsync(unitOfWork)
+            .BindAsync(file =>
+            {
+                _ = DeleteBlobSilently(file.BlobId);
+                return Result.Success();
+            });
     }
 
     public async Task<Result<(Stream Content, string ContentType, long SizeBytes)>> GetContentAsync(
         Guid fileId, long? rangeStart = null, long? rangeEnd = null, CancellationToken ct = default)
     {
         return await fileRepository.GetByIdAsync(fileId, CurrentUserId)
-            .BindAsync(file =>
-            {
-                return GetStreamAsync(file, rangeStart, rangeEnd, ct)
-                    .MapAsync(stream => (stream, file.ContentType, file.SizeBytes));
-            });
+            .BindAsync(file => GetStreamAsync(file, rangeStart, rangeEnd, ct)
+                .MapAsync(stream => (stream, file.ContentType, file.SizeBytes)));
     }
 
     public async Task<Result<File>> ReplaceContentAsync(
@@ -75,11 +80,15 @@ public class FileService(
             .BindAsync(async existingFile =>
             {
                 await using var bufferedContent = await BufferContentAsync(content, ct);
+                var oldBlobId = existingFile.BlobId;
+                existingFile.BlobId = Guid.NewGuid();
                 existingFile.ReplaceContent(contentType, bufferedContent.Length);
-                return await blobStorageService.ReplaceAsync(bufferedContent, existingFile, ct)
-                    .MapAsync(() => existingFile);
+                return await blobStorageService.SaveAsync(bufferedContent, existingFile.BlobId, ct)
+                    .MapAsync(() => (File: existingFile, OldBlobId: oldBlobId));
             })
-            .SaveChangesAsync(unitOfWork);
+            .SaveChangesAsync(unitOfWork)
+            .Act(pair => _ = DeleteBlobSilently(pair.OldBlobId))
+            .Map(pair => pair.File);
     }
 
     public async Task<Result<File>> MoveAsync(Guid fileId, Guid targetFolderId, CancellationToken ct = default)
@@ -95,8 +104,12 @@ public class FileService(
     {
         return await EnsureFolderExistsAsync(folderId)
             .BindAsync(_ => fileRepository.DeleteByFolderAsync(folderId))
-            .BindAsync(files => DeleteBlobsAsync(files, ct))
-            .SaveChangesAsync(unitOfWork);
+            .SaveChangesAsync(unitOfWork)
+            .BindAsync(files =>
+            {
+                DeleteBlobsInBackground(files.Select(f => f.BlobId).ToList());
+                return Result.Success();
+            });
     }
 
     public async Task<Result> ReorderAsync(Guid fileId, int position, CancellationToken ct = default)
@@ -116,11 +129,15 @@ public class FileService(
             .BindAsync(async file =>
             {
                 await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+                var oldBlobId = file.BlobId;
+                file.BlobId = Guid.NewGuid();
                 file.ReplaceContent(file.ContentType, stream.Length);
-                return await blobStorageService.ReplaceAsync(stream, file, ct)
-                    .MapAsync(() => file);
+                return await blobStorageService.SaveAsync(stream, file.BlobId, ct)
+                    .MapAsync(() => (File: file, OldBlobId: oldBlobId));
             })
-            .SaveChangesAsync(unitOfWork);
+            .SaveChangesAsync(unitOfWork)
+            .Act(pair => _ = DeleteBlobSilently(pair.OldBlobId))
+            .Map(pair => pair.File);
     }
 
     private static Result EnsureTextContentType(File file)
@@ -146,24 +163,34 @@ public class FileService(
         File file, long? rangeStart = null, long? rangeEnd = null, CancellationToken ct = default)
     {
         if (rangeStart is null && rangeEnd is null)
-            return await blobStorageService.GetAsync(file.Id, ct);
+            return await blobStorageService.GetAsync(file.BlobId, ct);
 
         var start = rangeStart ?? 0;
         var end = rangeEnd ?? file.SizeBytes;
 
-        return await blobStorageService.GetRangeAsync(file.Id, start, end, ct);
+        return await blobStorageService.GetRangeAsync(file.BlobId, start, end, ct);
     }
 
-    private async Task<Result> DeleteBlobsAsync(IReadOnlyList<File> files, CancellationToken ct)
+    private void DeleteBlobsInBackground(IReadOnlyList<Guid> blobIds)
     {
-        foreach (var file in files)
-        {
-            var result = await blobStorageService.DeleteAsync(file.Id, ct);
-            if (!result.IsSuccess)
-                return result;
-        }
+        foreach (var blobId in blobIds)
+            _ = DeleteBlobSilently(blobId);
+    }
 
-        return Result.Success();
+    private async Task DeleteBlobSilently(Guid blobId)
+    {
+        try
+        {
+            var result = await blobStorageService.DeleteAsync(blobId);
+            if (!result.IsSuccess)
+                logger.LogWarning(
+                    "Best-effort blob cleanup failed for {BlobId}: {Errors}",
+                    blobId, string.Join(", ", result.Errors));
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Best-effort blob cleanup failed for {BlobId}", blobId);
+        }
     }
 
     private static async Task<MemoryStream> BufferContentAsync(Stream content, CancellationToken ct)

--- a/backend/ShuKnow.Application/Services/FileService.cs
+++ b/backend/ShuKnow.Application/Services/FileService.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Ardalis.Result;
-using Microsoft.Extensions.Logging;
 using ShuKnow.Application.Extensions;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Domain.Entities;
@@ -14,9 +13,9 @@ public class FileService(
     IFileRepository fileRepository,
     IFolderRepository folderRepository,
     IBlobStorageService blobStorageService,
+    IBlobDeletionQueue blobDeletionQueue,
     ICurrentUserService currentUserService,
-    IUnitOfWork unitOfWork,
-    ILogger<FileService> logger)
+    IUnitOfWork unitOfWork)
     : IFileService
 {
     private Guid CurrentUserId => currentUserService.UserId;
@@ -58,11 +57,8 @@ public class FileService(
         return await fileRepository.GetByIdAsync(fileId, CurrentUserId)
             .ActAsync(file => fileRepository.DeleteAsync(file.Id))
             .SaveChangesAsync(unitOfWork)
-            .BindAsync(file =>
-            {
-                _ = DeleteBlobSilently(file.BlobId);
-                return Result.Success();
-            });
+            .ActAsync(file => blobDeletionQueue.EnqueueDeleteAsync(file.BlobId).AsTask())
+            .BindAsync(_ => Result.Success());
     }
 
     public async Task<Result<(Stream Content, string ContentType, long SizeBytes)>> GetContentAsync(
@@ -79,15 +75,20 @@ public class FileService(
         return await fileRepository.GetByIdForUpdateAsync(fileId, CurrentUserId)
             .BindAsync(async existingFile =>
             {
-                await using var bufferedContent = await BufferContentAsync(content, ct);
                 var oldBlobId = existingFile.BlobId;
-                existingFile.BlobId = Guid.NewGuid();
-                existingFile.ReplaceContent(contentType, bufferedContent.Length);
-                return await blobStorageService.SaveAsync(bufferedContent, existingFile.BlobId, ct)
-                    .MapAsync(() => (File: existingFile, OldBlobId: oldBlobId));
+                var newBlobId = Guid.NewGuid();
+                await using var upload = await PrepareUploadAsync(content, ct);
+
+                var saveResult = await blobStorageService.SaveAsync(upload.Content, newBlobId, ct);
+                if (!saveResult.IsSuccess)
+                    return saveResult.Map(() => (File: existingFile, OldBlobId: oldBlobId));
+
+                existingFile.ReplaceContent(contentType, upload.SizeBytes);
+                existingFile.BlobId = newBlobId;
+                return Result.Success((File: existingFile, OldBlobId: oldBlobId));
             })
             .SaveChangesAsync(unitOfWork)
-            .Act(pair => _ = DeleteBlobSilently(pair.OldBlobId))
+            .ActAsync(pair => blobDeletionQueue.EnqueueDeleteAsync(pair.OldBlobId).AsTask())
             .Map(pair => pair.File);
     }
 
@@ -105,11 +106,8 @@ public class FileService(
         return await EnsureFolderExistsAsync(folderId)
             .BindAsync(_ => fileRepository.DeleteByFolderAsync(folderId))
             .SaveChangesAsync(unitOfWork)
-            .BindAsync(files =>
-            {
-                DeleteBlobsInBackground(files.Select(f => f.BlobId).ToList());
-                return Result.Success();
-            });
+            .ActAsync(files => EnqueueDeletesAsync(files.Select(file => file.BlobId)))
+            .BindAsync(_ => Result.Success());
     }
 
     public async Task<Result> ReorderAsync(Guid fileId, int position, CancellationToken ct = default)
@@ -130,13 +128,18 @@ public class FileService(
             {
                 await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
                 var oldBlobId = file.BlobId;
-                file.BlobId = Guid.NewGuid();
+                var newBlobId = Guid.NewGuid();
+
+                var saveResult = await blobStorageService.SaveAsync(stream, newBlobId, ct);
+                if (!saveResult.IsSuccess)
+                    return saveResult.Map(() => (File: file, OldBlobId: oldBlobId));
+
                 file.ReplaceContent(file.ContentType, stream.Length);
-                return await blobStorageService.SaveAsync(stream, file.BlobId, ct)
-                    .MapAsync(() => (File: file, OldBlobId: oldBlobId));
+                file.BlobId = newBlobId;
+                return Result.Success((File: file, OldBlobId: oldBlobId));
             })
             .SaveChangesAsync(unitOfWork)
-            .Act(pair => _ = DeleteBlobSilently(pair.OldBlobId))
+            .ActAsync(pair => blobDeletionQueue.EnqueueDeleteAsync(pair.OldBlobId).AsTask())
             .Map(pair => pair.File);
     }
 
@@ -171,34 +174,21 @@ public class FileService(
         return await blobStorageService.GetRangeAsync(file.BlobId, start, end, ct);
     }
 
-    private void DeleteBlobsInBackground(IReadOnlyList<Guid> blobIds)
+    private async Task EnqueueDeletesAsync(IEnumerable<Guid> blobIds)
     {
         foreach (var blobId in blobIds)
-            _ = DeleteBlobSilently(blobId);
+            await blobDeletionQueue.EnqueueDeleteAsync(blobId);
     }
 
-    private async Task DeleteBlobSilently(Guid blobId)
+    private static async Task<PreparedUpload> PrepareUploadAsync(Stream content, CancellationToken ct)
     {
-        try
-        {
-            var result = await blobStorageService.DeleteAsync(blobId);
-            if (!result.IsSuccess)
-                logger.LogWarning(
-                    "Best-effort blob cleanup failed for {BlobId}: {Errors}",
-                    blobId, string.Join(", ", result.Errors));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Best-effort blob cleanup failed for {BlobId}", blobId);
-        }
-    }
+        if (content.CanSeek)
+            return new PreparedUpload(content, content.Length - content.Position);
 
-    private static async Task<MemoryStream> BufferContentAsync(Stream content, CancellationToken ct)
-    {
         var bufferedContent = new MemoryStream();
         await content.CopyToAsync(bufferedContent, ct);
         bufferedContent.Position = 0;
-        return bufferedContent;
+        return new PreparedUpload(bufferedContent, bufferedContent.Length, bufferedContent);
     }
 
     private static Result ApplyReorder(
@@ -228,5 +218,15 @@ public class FileService(
     {
         for (var i = 0; i < items.Count; i++)
             items[i].SortOrder = i;
+    }
+
+    private sealed class PreparedUpload(Stream content, long sizeBytes, IAsyncDisposable? disposable = null)
+        : IAsyncDisposable
+    {
+        public Stream Content { get; } = content;
+        public long SizeBytes { get; } = sizeBytes;
+
+        public ValueTask DisposeAsync()
+            => disposable?.DisposeAsync() ?? ValueTask.CompletedTask;
     }
 }

--- a/backend/ShuKnow.Application/ShuKnow.Application.csproj
+++ b/backend/ShuKnow.Application/ShuKnow.Application.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Ardalis.Result" Version="10.1.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/backend/ShuKnow.Domain/Entities/ChatAttachment.cs
+++ b/backend/ShuKnow.Domain/Entities/ChatAttachment.cs
@@ -5,6 +5,7 @@ namespace ShuKnow.Domain.Entities;
 public class ChatAttachment : IEntity<Guid>
 {
     public Guid Id { get; private set; }
+    public Guid BlobId { get; set; }
     public Guid UserId { get; private set; }
     public string FileName { get; private set; } = string.Empty;
     public string ContentType { get; private set; } = string.Empty;

--- a/backend/ShuKnow.Domain/Entities/File.cs
+++ b/backend/ShuKnow.Domain/Entities/File.cs
@@ -5,6 +5,7 @@ namespace ShuKnow.Domain.Entities;
 public class File : IEntity<Guid>, IOrderedItem
 {
     public Guid Id { get; private set; }
+    public Guid BlobId { get; set; }
 
     public Guid FolderId { get; private set; }
     public string Name { get; private set; } = string.Empty;

--- a/backend/ShuKnow.Domain/Repositories/IAttachmentRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IAttachmentRepository.cs
@@ -15,5 +15,5 @@ public interface IAttachmentRepository
 
     Task<Result> DeleteRangeAsync(IReadOnlyCollection<Guid> ids);
 
-    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync();
+    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Domain/Repositories/IAttachmentRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IAttachmentRepository.cs
@@ -15,5 +15,7 @@ public interface IAttachmentRepository
 
     Task<Result> DeleteRangeAsync(IReadOnlyCollection<Guid> ids);
 
-    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default);
+    Task<Result<IReadOnlySet<Guid>>> GetExistingBlobIdsAsync(
+        IReadOnlyCollection<Guid> blobIds,
+        CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Domain/Repositories/IAttachmentRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IAttachmentRepository.cs
@@ -14,4 +14,6 @@ public interface IAttachmentRepository
     Task<Result<IReadOnlyList<ChatAttachment>>> GetExpiredUnconsumedAsync(DateTimeOffset olderThan);
 
     Task<Result> DeleteRangeAsync(IReadOnlyCollection<Guid> ids);
+
+    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync();
 }

--- a/backend/ShuKnow.Domain/Repositories/IFileRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IFileRepository.cs
@@ -28,4 +28,6 @@ public interface IFileRepository
     Task<Result<IReadOnlyList<File>>> DeleteByFolderAsync(Guid folderId);
 
     Task<Result<IReadOnlyList<File>>> GetByFolderAsync(Guid folderId);
+
+    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync();
 }

--- a/backend/ShuKnow.Domain/Repositories/IFileRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IFileRepository.cs
@@ -29,5 +29,5 @@ public interface IFileRepository
 
     Task<Result<IReadOnlyList<File>>> GetByFolderAsync(Guid folderId);
 
-    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync();
+    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Domain/Repositories/IFileRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IFileRepository.cs
@@ -29,5 +29,7 @@ public interface IFileRepository
 
     Task<Result<IReadOnlyList<File>>> GetByFolderAsync(Guid folderId);
 
-    Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default);
+    Task<Result<IReadOnlySet<Guid>>> GetExistingBlobIdsAsync(
+        IReadOnlyCollection<Guid> blobIds,
+        CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Host/appsettings.Development.json
+++ b/backend/ShuKnow.Host/appsettings.Development.json
@@ -24,5 +24,23 @@
     },
     "Encryption": {
         "Key": "ThisIsMySuperSecretEncryptionKeyForDevelopment!@#"
+    },
+    "BlobStorage": {
+        "Provider": "FileSystem",
+        "FileSystem": {
+            "BasePath": "./data/blobs"
+        },
+        "S3": {
+            "ServiceUrl": "http://localhost:9000",
+            "AccessKey": "rustfsadmin",
+            "SecretKey": "rustfsadmin",
+            "BucketName": "shuknow",
+            "Prefix": "blobs",
+            "ForcePathStyle": true
+        },
+        "OrphanCleanup": {
+            "IntervalHours": 6,
+            "GracePeriodMinutes": 60
+        }
     }
 }

--- a/backend/ShuKnow.Host/appsettings.json
+++ b/backend/ShuKnow.Host/appsettings.json
@@ -6,6 +6,16 @@
         }
     },
     "AllowedHosts": "*",
+    "BlobStorage": {
+        "Provider": "FileSystem",
+        "FileSystem": {
+            "BasePath": "./data/blobs"
+        },
+        "OrphanCleanup": {
+            "IntervalHours": 6,
+            "GracePeriodMinutes": 60
+        }
+    },
     "AuthCookie": {
         "Name": "token",
         "HttpOnly": true,

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
@@ -147,6 +147,20 @@ public class S3BlobStorageProviderTests
         result.Status.Should().Be(ResultStatus.NotFound);
     }
 
+    [TestCase(-1, 10)]
+    [TestCase(10, 10)]
+    [TestCase(10, 5)]
+    public async Task GetRangeAsync_WhenRangeIsInvalid_ShouldReturnInvalid(long rangeStart, long rangeEnd)
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream("0123456789"u8.ToArray());
+        await sut.SaveAsync(input, blobId);
+
+        var result = await new BlobStorageService(sut).GetRangeAsync(blobId, rangeStart, rangeEnd);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+    }
+
     [Test]
     public async Task DeleteAsync_WhenBlobExists_ShouldRemoveBlob()
     {

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
@@ -1,0 +1,287 @@
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Ardalis.Result;
+using AwesomeAssertions;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.IntegrationTests.Services;
+
+[TestFixture]
+public class S3BlobStorageProviderTests
+{
+    private const string BucketName = "test-bucket";
+    private const string Prefix = "blobs";
+    private const int S3Port = 9000;
+
+    private IContainer? minioContainer;
+    private IAmazonS3? s3Client;
+    private S3BlobStorageProvider sut = null!;
+    private string? setupError;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        try
+        {
+            TestContext.Progress.WriteLine("[S3Test] OneTimeSetUp starting...");
+            minioContainer = new ContainerBuilder("minio/minio:latest")
+                .WithPortBinding(S3Port, true)
+                .WithEnvironment("MINIO_ROOT_USER", "minioadmin")
+                .WithEnvironment("MINIO_ROOT_PASSWORD", "minioadmin")
+                .WithCommand("server", "/data")
+                .WithWaitStrategy(Wait.ForUnixContainer()
+                    .UntilHttpRequestIsSucceeded(r => r
+                        .ForPort((ushort)S3Port)
+                        .ForPath("/minio/health/live")))
+                .Build();
+
+            TestContext.Progress.WriteLine("[S3Test] Container built, starting...");
+            await minioContainer.StartAsync();
+            TestContext.Progress.WriteLine("[S3Test] Container started");
+
+            var port = minioContainer.GetMappedPublicPort(S3Port);
+            var serviceUrl = $"http://{minioContainer.Hostname}:{port}";
+            TestContext.Progress.WriteLine($"[S3Test] MinIO at {serviceUrl}");
+
+            var config = new AmazonS3Config
+            {
+                ServiceURL = serviceUrl,
+                ForcePathStyle = true
+            };
+            var credentials = new BasicAWSCredentials("minioadmin", "minioadmin");
+            s3Client = new AmazonS3Client(credentials, config);
+
+            await s3Client.PutBucketAsync(BucketName);
+            TestContext.Progress.WriteLine("[S3Test] Bucket created, setup complete");
+        }
+        catch (Exception ex)
+        {
+            setupError = $"OneTimeSetUp failed: {ex}";
+            TestContext.Progress.WriteLine($"[S3Test] {setupError}");
+        }
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        if (setupError is not null)
+            Assert.Fail(setupError);
+
+        await CleanBucketAsync();
+
+        var logger = Substitute.For<ILogger<S3BlobStorageProvider>>();
+        sut = new S3BlobStorageProvider(s3Client!, BucketName, Prefix, logger);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        s3Client?.Dispose();
+        if (minioContainer is not null)
+            await minioContainer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task SaveAsync_WhenCalledWithValidStream_ShouldSaveBlob()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "hello s3"u8.ToArray();
+        using var stream = new MemoryStream(data);
+
+        var result = await sut.SaveAsync(stream, blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        var existsResult = await sut.ExistsAsync(blobId);
+        existsResult.Value.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetAsync_WhenBlobExists_ShouldReturnStream()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "test content"u8.ToArray();
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await using var output = result.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal(data);
+    }
+
+    [Test]
+    public async Task GetAsync_WhenBlobDoesNotExist_ShouldReturnNotFound()
+    {
+        var result = await sut.GetAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task GetRangeAsync_ShouldReturnCorrectRange()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "0123456789"u8.ToArray();
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetRangeAsync(blobId, 3, 7);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await using var output = result.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal("3456"u8.ToArray());
+    }
+
+    [Test]
+    public async Task GetRangeAsync_WhenBlobDoesNotExist_ShouldReturnNotFound()
+    {
+        var result = await sut.GetRangeAsync(Guid.NewGuid(), 0, 10);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenBlobExists_ShouldRemoveBlob()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream([1, 2, 3]);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.DeleteAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        var existsResult = await sut.ExistsAsync(blobId);
+        existsResult.Value.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenBlobDoesNotExist_ShouldReturnSuccess()
+    {
+        var result = await sut.DeleteAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.Ok);
+    }
+
+    [Test]
+    public async Task GetSizeAsync_WhenBlobExists_ShouldReturnCorrectSize()
+    {
+        var blobId = Guid.NewGuid();
+        var data = new byte[512];
+        Random.Shared.NextBytes(data);
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetSizeAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(512);
+    }
+
+    [Test]
+    public async Task GetSizeAsync_WhenBlobDoesNotExist_ShouldReturnNotFound()
+    {
+        var result = await sut.GetSizeAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task ExistsAsync_WhenBlobExists_ShouldReturnTrue()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream([1]);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.ExistsAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WhenBlobDoesNotExist_ShouldReturnFalse()
+    {
+        var result = await sut.ExistsAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ListAsync_ShouldReturnAllBlobIds()
+    {
+        var blobId1 = Guid.NewGuid();
+        var blobId2 = Guid.NewGuid();
+        using var s1 = new MemoryStream([1]);
+        using var s2 = new MemoryStream([2]);
+        await sut.SaveAsync(s1, blobId1);
+        await sut.SaveAsync(s2, blobId2);
+
+        var result = await sut.ListAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().HaveCount(2);
+        result.Value.Should().Contain(blobId1);
+        result.Value.Should().Contain(blobId2);
+    }
+
+    [Test]
+    public async Task ListAsync_WhenEmpty_ShouldReturnEmptyList()
+    {
+        var result = await sut.ListAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SaveAndGet_RoundTrip_ShouldPreserveContent()
+    {
+        var blobId = Guid.NewGuid();
+        var data = new byte[4096];
+        Random.Shared.NextBytes(data);
+        using var input = new MemoryStream(data);
+
+        await sut.SaveAsync(input, blobId);
+        var getResult = await sut.GetAsync(blobId);
+
+        await using var output = getResult.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal(data);
+    }
+
+    [Test]
+    public void GetObjectKey_ShouldIncludePrefix()
+    {
+        var blobId = Guid.NewGuid();
+        var key = sut.GetObjectKey(blobId);
+
+        key.Should().StartWith($"{Prefix}/");
+        key.Should().EndWith(blobId.ToString("N"));
+    }
+
+    private async Task CleanBucketAsync()
+    {
+        var listResponse = await s3Client!.ListObjectsV2Async(
+            new ListObjectsV2Request { BucketName = BucketName });
+
+        if (listResponse.S3Objects is null)
+            return;
+
+        foreach (var obj in listResponse.S3Objects)
+        {
+            await s3Client.DeleteObjectAsync(BucketName, obj.Key);
+        }
+    }
+}

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
@@ -218,7 +218,7 @@ public class S3BlobStorageProviderTests
     }
 
     [Test]
-    public async Task ListAsync_ShouldReturnAllBlobIds()
+    public async Task ListWithTimestampsAsync_ShouldReturnAllBlobIdsWithTimestamps()
     {
         var blobId1 = Guid.NewGuid();
         var blobId2 = Guid.NewGuid();
@@ -227,18 +227,20 @@ public class S3BlobStorageProviderTests
         await sut.SaveAsync(s1, blobId1);
         await sut.SaveAsync(s2, blobId2);
 
-        var result = await sut.ListAsync();
+        var result = await sut.ListWithTimestampsAsync();
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().HaveCount(2);
-        result.Value.Should().Contain(blobId1);
-        result.Value.Should().Contain(blobId2);
+        result.Value.Select(b => b.BlobId).Should().Contain(blobId1);
+        result.Value.Select(b => b.BlobId).Should().Contain(blobId2);
+        result.Value.Should().AllSatisfy(b =>
+            b.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(10)));
     }
 
     [Test]
-    public async Task ListAsync_WhenEmpty_ShouldReturnEmptyList()
+    public async Task ListWithTimestampsAsync_WhenEmpty_ShouldReturnEmptyList()
     {
-        var result = await sut.ListAsync();
+        var result = await sut.ListWithTimestampsAsync();
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeEmpty();

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
@@ -238,23 +238,21 @@ public class S3BlobStorageProviderTests
         await sut.SaveAsync(s1, blobId1);
         await sut.SaveAsync(s2, blobId2);
 
-        var result = await sut.ListWithTimestampsAsync();
+        var result = await CollectAsync(sut.StreamWithTimestampsAsync());
 
-        result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().HaveCount(2);
-        result.Value.Select(b => b.BlobId).Should().Contain(blobId1);
-        result.Value.Select(b => b.BlobId).Should().Contain(blobId2);
-        result.Value.Should().AllSatisfy(b =>
+        result.Should().HaveCount(2);
+        result.Select(b => b.BlobId).Should().Contain(blobId1);
+        result.Select(b => b.BlobId).Should().Contain(blobId2);
+        result.Should().AllSatisfy(b =>
             b.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(10)));
     }
 
     [Test]
     public async Task ListWithTimestampsAsync_WhenEmpty_ShouldReturnEmptyList()
     {
-        var result = await sut.ListWithTimestampsAsync();
+        var result = await CollectAsync(sut.StreamWithTimestampsAsync());
 
-        result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().BeEmpty();
+        result.Should().BeEmpty();
     }
 
     [Test]
@@ -296,5 +294,15 @@ public class S3BlobStorageProviderTests
         {
             await s3Client.DeleteObjectAsync(BucketName, obj.Key);
         }
+    }
+
+    private static async Task<List<(Guid BlobId, DateTimeOffset CreatedAt)>> CollectAsync(
+        IAsyncEnumerable<(Guid BlobId, DateTimeOffset CreatedAt)> blobs)
+    {
+        var result = new List<(Guid BlobId, DateTimeOffset CreatedAt)>();
+        await foreach (var blob in blobs)
+            result.Add(blob);
+
+        return result;
     }
 }

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Services/S3BlobStorageProviderTests.cs
@@ -17,8 +17,9 @@ public class S3BlobStorageProviderTests
     private const string BucketName = "test-bucket";
     private const string Prefix = "blobs";
     private const int S3Port = 9000;
+    private const int ConsolePort = 9001;
 
-    private IContainer? minioContainer;
+    private IContainer? rustFsContainer;
     private IAmazonS3? s3Client;
     private S3BlobStorageProvider sut = null!;
     private string? setupError;
@@ -28,36 +29,32 @@ public class S3BlobStorageProviderTests
     {
         try
         {
-            TestContext.Progress.WriteLine("[S3Test] OneTimeSetUp starting...");
-            minioContainer = new ContainerBuilder("minio/minio:latest")
+            rustFsContainer = new ContainerBuilder("rustfs/rustfs:latest")
                 .WithPortBinding(S3Port, true)
-                .WithEnvironment("MINIO_ROOT_USER", "minioadmin")
-                .WithEnvironment("MINIO_ROOT_PASSWORD", "minioadmin")
-                .WithCommand("server", "/data")
+                .WithPortBinding(ConsolePort, true)
+                .WithEnvironment("RUSTFS_ADDRESS", ":9000")
+                .WithEnvironment("RUSTFS_ACCESS_KEY", "rustfsadmin")
+                .WithEnvironment("RUSTFS_SECRET_KEY", "rustfsadmin")
+                .WithEnvironment("RUSTFS_CONSOLE_ENABLE", "true")
+                .WithCommand("/data")
                 .WithWaitStrategy(Wait.ForUnixContainer()
-                    .UntilHttpRequestIsSucceeded(r => r
-                        .ForPort((ushort)S3Port)
-                        .ForPath("/minio/health/live")))
+                    .UntilInternalTcpPortIsAvailable(S3Port))
                 .Build();
+            
+            await rustFsContainer.StartAsync();
 
-            TestContext.Progress.WriteLine("[S3Test] Container built, starting...");
-            await minioContainer.StartAsync();
-            TestContext.Progress.WriteLine("[S3Test] Container started");
-
-            var port = minioContainer.GetMappedPublicPort(S3Port);
-            var serviceUrl = $"http://{minioContainer.Hostname}:{port}";
-            TestContext.Progress.WriteLine($"[S3Test] MinIO at {serviceUrl}");
+            var port = rustFsContainer.GetMappedPublicPort(S3Port);
+            var serviceUrl = $"http://{rustFsContainer.Hostname}:{port}";
 
             var config = new AmazonS3Config
             {
                 ServiceURL = serviceUrl,
                 ForcePathStyle = true
             };
-            var credentials = new BasicAWSCredentials("minioadmin", "minioadmin");
+            var credentials = new BasicAWSCredentials("rustfsadmin", "rustfsadmin");
             s3Client = new AmazonS3Client(credentials, config);
 
             await s3Client.PutBucketAsync(BucketName);
-            TestContext.Progress.WriteLine("[S3Test] Bucket created, setup complete");
         }
         catch (Exception ex)
         {
@@ -82,8 +79,8 @@ public class S3BlobStorageProviderTests
     public async Task OneTimeTearDown()
     {
         s3Client?.Dispose();
-        if (minioContainer is not null)
-            await minioContainer.DisposeAsync();
+        if (rustFsContainer is not null)
+            await rustFsContainer.DisposeAsync();
     }
 
     [Test]

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/ShuKnow.Infrastructure.IntegrationTests.csproj
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/ShuKnow.Infrastructure.IntegrationTests.csproj
@@ -11,16 +11,19 @@
 
     <ItemGroup>
         <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AWSSDK.S3" Version="4.0.19.4" />
         <PackageReference Include="coverlet.collector" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Testcontainers" Version="4.11.0" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="NUnit.Framework"/>
+        <Using Include="NUnit.Framework" />
     </ItemGroup>
 
     <ItemGroup>

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupRunnerTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupRunnerTests.cs
@@ -61,9 +61,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(blobId1, oldTimestamp), (blobId2, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(blobId1));
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(blobId2));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -81,9 +81,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(referencedId, oldTimestamp), (orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(referencedId));
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(orphanId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Success()));
@@ -103,9 +103,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(orphanId, recentTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -131,9 +131,9 @@ public class BlobOrphanCleanupRunnerTests
                 (recentOrphan, recentTimestamp),
                 (referencedId, oldTimestamp)
             ]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(referencedId));
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Success()));
@@ -157,8 +157,8 @@ public class BlobOrphanCleanupRunnerTests
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
 
         deleted.Should().Be(0);
-        await fileRepository.DidNotReceive().GetAllBlobIdsAsync();
-        await attachmentRepository.DidNotReceive().GetAllBlobIdsAsync();
+        await fileRepository.DidNotReceive().GetAllBlobIdsAsync(Arg.Any<CancellationToken>());
+        await attachmentRepository.DidNotReceive().GetAllBlobIdsAsync(Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -169,9 +169,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<IReadOnlySet<Guid>>.Error("db error")));
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -188,9 +188,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<IReadOnlySet<Guid>>.Error("db error")));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -208,9 +208,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(orphan1, oldTimestamp), (orphan2, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(orphan1, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Error("delete failed")));
@@ -232,9 +232,9 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(sharedBlobId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(sharedBlobId));
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(sharedBlobId));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -263,15 +263,39 @@ public class BlobOrphanCleanupRunnerTests
 
         provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessTimestamps([(orphanId, timestamp)]));
-        fileRepository.GetAllBlobIdsAsync()
+        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync()
+        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
 
         var deleted = await customSut.RunCleanupAsync(CancellationToken.None);
 
         deleted.Should().Be(0);
         await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_ShouldPassCancellationTokenToBlobIdQueries()
+    {
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+        var orphanId = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(token)
+            .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync(token)
+            .Returns(SuccessBlobIds());
+        attachmentRepository.GetAllBlobIdsAsync(token)
+            .Returns(SuccessBlobIds());
+        provider.DeleteAsync(orphanId, token)
+            .Returns(Task.FromResult(Result.Success()));
+
+        var deleted = await sut.RunCleanupAsync(token);
+
+        deleted.Should().Be(1);
+        await fileRepository.Received(1).GetAllBlobIdsAsync(token);
+        await attachmentRepository.Received(1).GetAllBlobIdsAsync(token);
     }
 
     private static Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> SuccessTimestamps(

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupRunnerTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupRunnerTests.cs
@@ -43,8 +43,8 @@ public class BlobOrphanCleanupRunnerTests
     [Test]
     public async Task RunCleanupAsync_WhenNoBlobsExist_ShouldReturnZeroAndNotDelete()
     {
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([]));
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([]));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
 
@@ -59,11 +59,15 @@ public class BlobOrphanCleanupRunnerTests
         var blobId2 = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(blobId1, oldTimestamp), (blobId2, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(blobId1, oldTimestamp), (blobId2, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(blobId1) && ids.Contains(blobId2)),
+                Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(blobId1));
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        attachmentRepository.GetExistingBlobIdsAsync(
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(blobId1) && ids.Contains(blobId2)),
+                Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(blobId2));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -79,11 +83,13 @@ public class BlobOrphanCleanupRunnerTests
         var orphanId = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(referencedId, oldTimestamp), (orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessBlobIds(referencedId));
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(referencedId, oldTimestamp), (orphanId, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(call => SuccessBlobIds(call.ArgAt<IReadOnlyCollection<Guid>>(0).Contains(referencedId)
+                ? [referencedId]
+                : []));
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(orphanId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Success()));
@@ -101,17 +107,17 @@ public class BlobOrphanCleanupRunnerTests
         var orphanId = Guid.NewGuid();
         var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-30);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(orphanId, recentTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessBlobIds());
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(orphanId, recentTimestamp)]));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
 
         deleted.Should().Be(0);
         await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await fileRepository.DidNotReceive()
+            .GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
+        await attachmentRepository.DidNotReceive()
+            .GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -124,16 +130,18 @@ public class BlobOrphanCleanupRunnerTests
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-3);
         var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-10);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([
                 (orphan1, oldTimestamp),
                 (orphan2, oldTimestamp),
                 (recentOrphan, recentTimestamp),
                 (referencedId, oldTimestamp)
             ]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessBlobIds(referencedId));
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(call => SuccessBlobIds(call.ArgAt<IReadOnlyCollection<Guid>>(0).Contains(referencedId)
+                ? [referencedId]
+                : []));
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Success()));
@@ -150,15 +158,16 @@ public class BlobOrphanCleanupRunnerTests
     [Test]
     public async Task RunCleanupAsync_WhenListBlobsFails_ShouldReturnZeroAndNotQueryDb()
     {
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(
-                Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>.Error("storage error")));
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => ThrowOnEnumeration<(Guid BlobId, DateTimeOffset CreatedAt)>(new InvalidOperationException("storage error")));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
 
         deleted.Should().Be(0);
-        await fileRepository.DidNotReceive().GetAllBlobIdsAsync(Arg.Any<CancellationToken>());
-        await attachmentRepository.DidNotReceive().GetAllBlobIdsAsync(Arg.Any<CancellationToken>());
+        await fileRepository.DidNotReceive()
+            .GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
+        await attachmentRepository.DidNotReceive()
+            .GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -167,11 +176,11 @@ public class BlobOrphanCleanupRunnerTests
         var orphanId = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(orphanId, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<IReadOnlySet<Guid>>.Error("db error")));
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -186,11 +195,11 @@ public class BlobOrphanCleanupRunnerTests
         var orphanId = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(orphanId, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<IReadOnlySet<Guid>>.Error("db error")));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -206,11 +215,11 @@ public class BlobOrphanCleanupRunnerTests
         var orphan2 = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(orphan1, oldTimestamp), (orphan2, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(orphan1, oldTimestamp), (orphan2, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(orphan1, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result.Error("delete failed")));
@@ -230,11 +239,11 @@ public class BlobOrphanCleanupRunnerTests
         var sharedBlobId = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(sharedBlobId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(sharedBlobId, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(sharedBlobId));
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds(sharedBlobId));
 
         var deleted = await sut.RunCleanupAsync(CancellationToken.None);
@@ -261,11 +270,11 @@ public class BlobOrphanCleanupRunnerTests
         var orphanId = Guid.NewGuid();
         var timestamp = DateTimeOffset.UtcNow.AddMinutes(-90);
 
-        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
-            .Returns(SuccessTimestamps([(orphanId, timestamp)]));
-        fileRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps([(orphanId, timestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync(Arg.Any<CancellationToken>())
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(SuccessBlobIds());
 
         var deleted = await customSut.RunCleanupAsync(CancellationToken.None);
@@ -282,11 +291,11 @@ public class BlobOrphanCleanupRunnerTests
         var orphanId = Guid.NewGuid();
         var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
 
-        provider.ListWithTimestampsAsync(token)
-            .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
-        fileRepository.GetAllBlobIdsAsync(token)
+        provider.StreamWithTimestampsAsync(token)
+            .Returns(StreamTimestamps([(orphanId, oldTimestamp)]));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), token)
             .Returns(SuccessBlobIds());
-        attachmentRepository.GetAllBlobIdsAsync(token)
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), token)
             .Returns(SuccessBlobIds());
         provider.DeleteAsync(orphanId, token)
             .Returns(Task.FromResult(Result.Success()));
@@ -294,20 +303,62 @@ public class BlobOrphanCleanupRunnerTests
         var deleted = await sut.RunCleanupAsync(token);
 
         deleted.Should().Be(1);
-        await fileRepository.Received(1).GetAllBlobIdsAsync(token);
-        await attachmentRepository.Received(1).GetAllBlobIdsAsync(token);
+        await fileRepository.Received(1)
+            .GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), token);
+        await attachmentRepository.Received(1)
+            .GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), token);
     }
 
-    private static Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> SuccessTimestamps(
-        List<(Guid BlobId, DateTimeOffset CreatedAt)> blobs)
+    [Test]
+    public async Task RunCleanupAsync_WhenCandidateCountExceedsBatchSize_ShouldQueryDatabaseInBatches()
     {
-        return Task.FromResult(
-            Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs));
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+        var orphanIds = Enumerable.Range(0, 300)
+            .Select(_ => Guid.NewGuid())
+            .ToArray();
+        var observedBatchSizes = new List<int>();
+
+        provider.StreamWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(StreamTimestamps(orphanIds.Select(id => (id, oldTimestamp)).ToList()));
+        fileRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                observedBatchSizes.Add(call.ArgAt<IReadOnlyCollection<Guid>>(0).Count);
+                return SuccessBlobIds();
+            });
+        attachmentRepository.GetExistingBlobIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(SuccessBlobIds());
+        provider.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(orphanIds.Length);
+        observedBatchSizes.Should().Equal(256, 44);
     }
 
     private static Task<Result<IReadOnlySet<Guid>>> SuccessBlobIds(params Guid[] ids)
     {
         IReadOnlySet<Guid> set = new HashSet<Guid>(ids);
         return Task.FromResult(Result.Success(set));
+    }
+
+    private static async IAsyncEnumerable<(Guid BlobId, DateTimeOffset CreatedAt)> StreamTimestamps(
+        List<(Guid BlobId, DateTimeOffset CreatedAt)> blobs)
+    {
+        foreach (var blob in blobs)
+        {
+            yield return blob;
+            await Task.Yield();
+        }
+    }
+
+    private static async IAsyncEnumerable<T> ThrowOnEnumeration<T>(Exception ex)
+    {
+        if (Environment.TickCount == int.MinValue)
+            yield return default!;
+
+        await Task.Yield();
+        throw ex;
     }
 }

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupRunnerTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupRunnerTests.cs
@@ -1,0 +1,289 @@
+using Ardalis.Result;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using ShuKnow.Application.Common;
+using ShuKnow.Domain.Repositories;
+using ShuKnow.Infrastructure.Interfaces;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.Tests.Services;
+
+public class BlobOrphanCleanupRunnerTests
+{
+    private IBlobStorageProvider provider = null!;
+    private IFileRepository fileRepository = null!;
+    private IAttachmentRepository attachmentRepository = null!;
+    private IOptions<OrphanCleanupOptions> options = null!;
+    private ILogger<BlobOrphanCleanupRunner> logger = null!;
+    private BlobOrphanCleanupRunner sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        provider = Substitute.For<IBlobStorageProvider>();
+        fileRepository = Substitute.For<IFileRepository>();
+        attachmentRepository = Substitute.For<IAttachmentRepository>();
+        logger = Substitute.For<ILogger<BlobOrphanCleanupRunner>>();
+        options = Options.Create(new OrphanCleanupOptions
+        {
+            IntervalHours = 6,
+            GracePeriodMinutes = 60
+        });
+
+        sut = new BlobOrphanCleanupRunner(
+            provider,
+            fileRepository,
+            attachmentRepository,
+            options,
+            logger);
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenNoBlobsExist_ShouldReturnZeroAndNotDelete()
+    {
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([]));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenAllBlobsAreReferenced_ShouldReturnZero()
+    {
+        var blobId1 = Guid.NewGuid();
+        var blobId2 = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(blobId1, oldTimestamp), (blobId2, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds(blobId1));
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds(blobId2));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenOrphansExistPastGracePeriod_ShouldDeleteThem()
+    {
+        var referencedId = Guid.NewGuid();
+        var orphanId = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(referencedId, oldTimestamp), (orphanId, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds(referencedId));
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        provider.DeleteAsync(orphanId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(1);
+        await provider.Received(1).DeleteAsync(orphanId, Arg.Any<CancellationToken>());
+        await provider.DidNotReceive().DeleteAsync(referencedId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenOrphanIsWithinGracePeriod_ShouldNotDeleteIt()
+    {
+        var orphanId = Guid.NewGuid();
+        var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-30);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(orphanId, recentTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenMultipleOrphansExist_ShouldDeleteAllPastGracePeriod()
+    {
+        var orphan1 = Guid.NewGuid();
+        var orphan2 = Guid.NewGuid();
+        var recentOrphan = Guid.NewGuid();
+        var referencedId = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-3);
+        var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-10);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([
+                (orphan1, oldTimestamp),
+                (orphan2, oldTimestamp),
+                (recentOrphan, recentTimestamp),
+                (referencedId, oldTimestamp)
+            ]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds(referencedId));
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        provider.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(2);
+        await provider.Received(1).DeleteAsync(orphan1, Arg.Any<CancellationToken>());
+        await provider.Received(1).DeleteAsync(orphan2, Arg.Any<CancellationToken>());
+        await provider.DidNotReceive().DeleteAsync(recentOrphan, Arg.Any<CancellationToken>());
+        await provider.DidNotReceive().DeleteAsync(referencedId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenListBlobsFails_ShouldReturnZeroAndNotQueryDb()
+    {
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>.Error("storage error")));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await fileRepository.DidNotReceive().GetAllBlobIdsAsync();
+        await attachmentRepository.DidNotReceive().GetAllBlobIdsAsync();
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenFileRepoFails_ShouldReturnZeroAndNotDelete()
+    {
+        var orphanId = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(Task.FromResult(Result<IReadOnlySet<Guid>>.Error("db error")));
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenAttachmentRepoFails_ShouldReturnZeroAndNotDelete()
+    {
+        var orphanId = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(orphanId, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(Task.FromResult(Result<IReadOnlySet<Guid>>.Error("db error")));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenDeleteFails_ShouldContinueAndCountOnlySuccessful()
+    {
+        var orphan1 = Guid.NewGuid();
+        var orphan2 = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(orphan1, oldTimestamp), (orphan2, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        provider.DeleteAsync(orphan1, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Error("delete failed")));
+        provider.DeleteAsync(orphan2, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(1);
+        await provider.Received(1).DeleteAsync(orphan1, Arg.Any<CancellationToken>());
+        await provider.Received(1).DeleteAsync(orphan2, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_WhenBlobReferencedByBothRepos_ShouldNotDeleteIt()
+    {
+        var sharedBlobId = Guid.NewGuid();
+        var oldTimestamp = DateTimeOffset.UtcNow.AddHours(-2);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(sharedBlobId, oldTimestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds(sharedBlobId));
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds(sharedBlobId));
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_ShouldUseConfiguredGracePeriod()
+    {
+        var customOptions = Options.Create(new OrphanCleanupOptions
+        {
+            IntervalHours = 1,
+            GracePeriodMinutes = 120
+        });
+        var customSut = new BlobOrphanCleanupRunner(
+            provider,
+            fileRepository,
+            attachmentRepository,
+            customOptions,
+            logger);
+
+        var orphanId = Guid.NewGuid();
+        var timestamp = DateTimeOffset.UtcNow.AddMinutes(-90);
+
+        provider.ListWithTimestampsAsync(Arg.Any<CancellationToken>())
+            .Returns(SuccessTimestamps([(orphanId, timestamp)]));
+        fileRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+        attachmentRepository.GetAllBlobIdsAsync()
+            .Returns(SuccessBlobIds());
+
+        var deleted = await customSut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        await provider.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    private static Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> SuccessTimestamps(
+        List<(Guid BlobId, DateTimeOffset CreatedAt)> blobs)
+    {
+        return Task.FromResult(
+            Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs));
+    }
+
+    private static Task<Result<IReadOnlySet<Guid>>> SuccessBlobIds(params Guid[] ids)
+    {
+        IReadOnlySet<Guid> set = new HashSet<Guid>(ids);
+        return Task.FromResult(Result.Success(set));
+    }
+}

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupServiceTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupServiceTests.cs
@@ -57,4 +57,29 @@ public class BlobOrphanCleanupServiceTests
         scopeFactory.Received(1).CreateScope();
         await runner.Received(1).RunCleanupAsync(CancellationToken.None);
     }
+
+    [Test]
+    public async Task StartAsync_ShouldRunCleanupImmediatelyBeforeWaitingForInterval()
+    {
+        using var callObserved = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var stopTokenSource = new CancellationTokenSource();
+        var firstCallSeen = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        runner.RunCleanupAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                firstCallSeen.TrySetResult(true);
+                return 0;
+            });
+
+        await sut.StartAsync(stopTokenSource.Token);
+
+        var completed = await Task.WhenAny(firstCallSeen.Task, Task.Delay(Timeout.Infinite, callObserved.Token));
+
+        completed.Should().BeSameAs(firstCallSeen.Task);
+        await runner.Received(1).RunCleanupAsync(Arg.Any<CancellationToken>());
+
+        stopTokenSource.Cancel();
+        await sut.StopAsync(CancellationToken.None);
+    }
 }

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupServiceTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobOrphanCleanupServiceTests.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using ShuKnow.Application.Common;
+using ShuKnow.Infrastructure.Interfaces;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.Tests.Services;
+
+public class BlobOrphanCleanupServiceTests
+{
+    private IServiceScopeFactory scopeFactory = null!;
+    private IBlobOrphanCleanupRunner runner = null!;
+    private IOptions<OrphanCleanupOptions> options = null!;
+    private ILogger<BlobOrphanCleanupService> logger = null!;
+    private BlobOrphanCleanupService sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        runner = Substitute.For<IBlobOrphanCleanupRunner>();
+        logger = Substitute.For<ILogger<BlobOrphanCleanupService>>();
+        options = Options.Create(new OrphanCleanupOptions
+        {
+            IntervalHours = 6,
+            GracePeriodMinutes = 60
+        });
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBlobOrphanCleanupRunner)).Returns(runner);
+
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(serviceProvider);
+
+        scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        sut = new BlobOrphanCleanupService(scopeFactory, options, logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        sut.Dispose();
+    }
+
+    [Test]
+    public async Task RunCleanupAsync_ShouldResolveScopedRunnerAndReturnDeletedCount()
+    {
+        runner.RunCleanupAsync(Arg.Any<CancellationToken>()).Returns(3);
+
+        var deleted = await sut.RunCleanupAsync(CancellationToken.None);
+
+        deleted.Should().Be(3);
+        scopeFactory.Received(1).CreateScope();
+        await runner.Received(1).RunCleanupAsync(CancellationToken.None);
+    }
+}

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobStorageServiceTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobStorageServiceTests.cs
@@ -99,6 +99,21 @@ public class BlobStorageServiceTests
         result.Status.Should().Be(ResultStatus.Invalid);
     }
 
+    [TestCase(-1, 10)]
+    [TestCase(10, 10)]
+    [TestCase(10, 5)]
+    public async Task GetRangeAsync_WhenRangeIsInvalid_ShouldReturnInvalidWithoutCallingProvider(
+        long rangeStart, long rangeEnd)
+    {
+        var blobId = Guid.NewGuid();
+
+        var result = await sut.GetRangeAsync(blobId, rangeStart, rangeEnd);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        await provider.DidNotReceive()
+            .GetRangeAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
     [Test]
     public async Task DeleteAsync_ShouldDelegateToProvider()
     {

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BlobStorageServiceTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BlobStorageServiceTests.cs
@@ -1,0 +1,152 @@
+using Ardalis.Result;
+using AwesomeAssertions;
+using NSubstitute;
+using ShuKnow.Infrastructure.Interfaces;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.Tests.Services;
+
+public class BlobStorageServiceTests
+{
+    private IBlobStorageProvider provider = null!;
+    private BlobStorageService sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        provider = Substitute.For<IBlobStorageProvider>();
+        sut = new BlobStorageService(provider);
+    }
+
+    [Test]
+    public async Task SaveAsync_ShouldDelegateToProvider()
+    {
+        var blobId = Guid.NewGuid();
+        using var stream = new MemoryStream([1, 2, 3]);
+        provider.SaveAsync(stream, blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var result = await sut.SaveAsync(stream, blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await provider.Received(1).SaveAsync(stream, blobId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task SaveAsync_WhenProviderFails_ShouldReturnError()
+    {
+        var blobId = Guid.NewGuid();
+        using var stream = new MemoryStream([1]);
+        provider.SaveAsync(stream, blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Error("save failed")));
+
+        var result = await sut.SaveAsync(stream, blobId);
+
+        result.Status.Should().Be(ResultStatus.Error);
+    }
+
+    [Test]
+    public async Task GetAsync_ShouldDelegateToProvider()
+    {
+        var blobId = Guid.NewGuid();
+        var expectedStream = new MemoryStream([1, 2]);
+        provider.GetAsync(blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success<Stream>(expectedStream)));
+
+        var result = await sut.GetAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeSameAs(expectedStream);
+        await provider.Received(1).GetAsync(blobId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GetAsync_WhenProviderReturnsNotFound_ShouldReturnNotFound()
+    {
+        var blobId = Guid.NewGuid();
+        provider.GetAsync(blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<Stream>.NotFound()));
+
+        var result = await sut.GetAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task GetRangeAsync_ShouldDelegateToProvider()
+    {
+        var blobId = Guid.NewGuid();
+        var expectedStream = new MemoryStream([3, 4]);
+        provider.GetRangeAsync(blobId, 10, 20, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success<Stream>(expectedStream)));
+
+        var result = await sut.GetRangeAsync(blobId, 10, 20);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeSameAs(expectedStream);
+        await provider.Received(1).GetRangeAsync(blobId, 10, 20, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GetRangeAsync_WhenProviderReturnsInvalid_ShouldReturnInvalid()
+    {
+        var blobId = Guid.NewGuid();
+        provider.GetRangeAsync(blobId, 100, 200, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<Stream>.Invalid(new ValidationError("bad range"))));
+
+        var result = await sut.GetRangeAsync(blobId, 100, 200);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+    }
+
+    [Test]
+    public async Task DeleteAsync_ShouldDelegateToProvider()
+    {
+        var blobId = Guid.NewGuid();
+        provider.DeleteAsync(blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var result = await sut.DeleteAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await provider.Received(1).DeleteAsync(blobId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenProviderFails_ShouldReturnError()
+    {
+        var blobId = Guid.NewGuid();
+        provider.DeleteAsync(blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Error("delete failed")));
+
+        var result = await sut.DeleteAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Error);
+    }
+
+    [Test]
+    public async Task GetSizeAsync_ShouldDelegateToProvider()
+    {
+        var blobId = Guid.NewGuid();
+        provider.GetSizeAsync(blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success(1024L)));
+
+        var result = await sut.GetSizeAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(1024L);
+        await provider.Received(1).GetSizeAsync(blobId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GetSizeAsync_WhenProviderReturnsNotFound_ShouldReturnNotFound()
+    {
+        var blobId = Guid.NewGuid();
+        provider.GetSizeAsync(blobId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<long>.NotFound()));
+
+        var result = await sut.GetSizeAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/backend/ShuKnow.Infrastructure.Tests/Services/BoundedReadStreamTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/BoundedReadStreamTests.cs
@@ -1,0 +1,30 @@
+using AwesomeAssertions;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.Tests.Services;
+
+[TestFixture]
+public class BoundedReadStreamTests
+{
+    [Test]
+    public async Task DisposeAsync_ShouldUseBaseDisposePath()
+    {
+        await using var inner = new MemoryStream([1, 2, 3]);
+        var stream = new TrackingBoundedReadStream(inner, inner.Length);
+
+        await stream.DisposeAsync();
+
+        stream.DisposeCalled.Should().BeTrue();
+    }
+
+    private sealed class TrackingBoundedReadStream(Stream inner, long length) : BoundedReadStream(inner, length)
+    {
+        public bool DisposeCalled { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalled = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/backend/ShuKnow.Infrastructure.Tests/Services/FileSystemBlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/FileSystemBlobStorageProviderTests.cs
@@ -227,7 +227,7 @@ public class FileSystemBlobStorageProviderTests
     }
 
     [Test]
-    public async Task ListAsync_ShouldReturnAllBlobIds()
+    public async Task ListWithTimestampsAsync_ShouldReturnAllBlobIdsWithTimestamps()
     {
         var blobId1 = Guid.NewGuid();
         var blobId2 = Guid.NewGuid();
@@ -236,31 +236,33 @@ public class FileSystemBlobStorageProviderTests
         await sut.SaveAsync(s1, blobId1);
         await sut.SaveAsync(s2, blobId2);
 
-        var result = await sut.ListAsync();
+        var result = await sut.ListWithTimestampsAsync();
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().HaveCount(2);
-        result.Value.Should().Contain(blobId1);
-        result.Value.Should().Contain(blobId2);
+        result.Value.Select(b => b.BlobId).Should().Contain(blobId1);
+        result.Value.Select(b => b.BlobId).Should().Contain(blobId2);
+        result.Value.Should().AllSatisfy(b =>
+            b.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5)));
     }
 
     [Test]
-    public async Task ListAsync_WhenEmpty_ShouldReturnEmptyList()
+    public async Task ListWithTimestampsAsync_WhenEmpty_ShouldReturnEmptyList()
     {
-        var result = await sut.ListAsync();
+        var result = await sut.ListWithTimestampsAsync();
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeEmpty();
     }
 
     [Test]
-    public async Task ListAsync_WhenBasePathDoesNotExist_ShouldReturnEmptyList()
+    public async Task ListWithTimestampsAsync_WhenBasePathDoesNotExist_ShouldReturnEmptyList()
     {
         var nonExistentDir = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}");
         var logger = Substitute.For<ILogger<FileSystemBlobStorageProvider>>();
         var provider = new FileSystemBlobStorageProvider(nonExistentDir, logger);
 
-        var result = await provider.ListAsync();
+        var result = await provider.ListWithTimestampsAsync();
 
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeEmpty();

--- a/backend/ShuKnow.Infrastructure.Tests/Services/FileSystemBlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/FileSystemBlobStorageProviderTests.cs
@@ -236,23 +236,21 @@ public class FileSystemBlobStorageProviderTests
         await sut.SaveAsync(s1, blobId1);
         await sut.SaveAsync(s2, blobId2);
 
-        var result = await sut.ListWithTimestampsAsync();
+        var result = await CollectAsync(sut.StreamWithTimestampsAsync());
 
-        result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().HaveCount(2);
-        result.Value.Select(b => b.BlobId).Should().Contain(blobId1);
-        result.Value.Select(b => b.BlobId).Should().Contain(blobId2);
-        result.Value.Should().AllSatisfy(b =>
+        result.Should().HaveCount(2);
+        result.Select(b => b.BlobId).Should().Contain(blobId1);
+        result.Select(b => b.BlobId).Should().Contain(blobId2);
+        result.Should().AllSatisfy(b =>
             b.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5)));
     }
 
     [Test]
     public async Task ListWithTimestampsAsync_WhenEmpty_ShouldReturnEmptyList()
     {
-        var result = await sut.ListWithTimestampsAsync();
+        var result = await CollectAsync(sut.StreamWithTimestampsAsync());
 
-        result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().BeEmpty();
+        result.Should().BeEmpty();
     }
 
     [Test]
@@ -262,10 +260,9 @@ public class FileSystemBlobStorageProviderTests
         var logger = Substitute.For<ILogger<FileSystemBlobStorageProvider>>();
         var provider = new FileSystemBlobStorageProvider(nonExistentDir, logger);
 
-        var result = await provider.ListWithTimestampsAsync();
+        var result = await CollectAsync(provider.StreamWithTimestampsAsync());
 
-        result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().BeEmpty();
+        result.Should().BeEmpty();
     }
 
     [Test]
@@ -296,5 +293,15 @@ public class FileSystemBlobStorageProviderTests
         result.Status.Should().Be(ResultStatus.Ok);
         var sizeResult = await sut.GetSizeAsync(blobId);
         sizeResult.Value.Should().Be(0);
+    }
+
+    private static async Task<List<(Guid BlobId, DateTimeOffset CreatedAt)>> CollectAsync(
+        IAsyncEnumerable<(Guid BlobId, DateTimeOffset CreatedAt)> blobs)
+    {
+        var result = new List<(Guid BlobId, DateTimeOffset CreatedAt)>();
+        await foreach (var blob in blobs)
+            result.Add(blob);
+
+        return result;
     }
 }

--- a/backend/ShuKnow.Infrastructure.Tests/Services/FileSystemBlobStorageProviderTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/FileSystemBlobStorageProviderTests.cs
@@ -1,0 +1,298 @@
+using Ardalis.Result;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.Tests.Services;
+
+public class FileSystemBlobStorageProviderTests
+{
+    private string tempDir = null!;
+    private FileSystemBlobStorageProvider sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), $"blob-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var logger = Substitute.For<ILogger<FileSystemBlobStorageProvider>>();
+        sut = new FileSystemBlobStorageProvider(tempDir, logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task SaveAsync_WhenCalledWithValidStream_ShouldWriteFileToDisk()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "hello world"u8.ToArray();
+        using var stream = new MemoryStream(data);
+
+        var result = await sut.SaveAsync(stream, blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        var filePath = sut.GetBlobPath(blobId);
+        File.Exists(filePath).Should().BeTrue();
+        (await File.ReadAllBytesAsync(filePath)).Should().Equal(data);
+    }
+
+    [Test]
+    public async Task SaveAsync_ShouldCreateShardedDirectoryStructure()
+    {
+        var blobId = Guid.NewGuid();
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        await sut.SaveAsync(stream, blobId);
+
+        var expectedShard = blobId.ToString("N")[..2];
+        var shardDir = Path.Combine(tempDir, expectedShard);
+        Directory.Exists(shardDir).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SaveAsync_WhenBlobAlreadyExists_ShouldReturnError()
+    {
+        var blobId = Guid.NewGuid();
+        using var stream1 = new MemoryStream([1]);
+        using var stream2 = new MemoryStream([2]);
+
+        await sut.SaveAsync(stream1, blobId);
+        var result = await sut.SaveAsync(stream2, blobId);
+
+        result.Status.Should().Be(ResultStatus.Error);
+    }
+
+    [Test]
+    public async Task GetAsync_WhenBlobExists_ShouldReturnStream()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "test content"u8.ToArray();
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await using var output = result.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal(data);
+    }
+
+    [Test]
+    public async Task GetAsync_WhenBlobDoesNotExist_ShouldReturnNotFound()
+    {
+        var result = await sut.GetAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task GetRangeAsync_ShouldReturnCorrectRange()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "0123456789"u8.ToArray();
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetRangeAsync(blobId, 3, 7);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await using var output = result.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal("3456"u8.ToArray());
+    }
+
+    [Test]
+    public async Task GetRangeAsync_WhenRangeExceedsFileSize_ShouldClampToEnd()
+    {
+        var blobId = Guid.NewGuid();
+        var data = "abcde"u8.ToArray();
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetRangeAsync(blobId, 3, 100);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await using var output = result.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal("de"u8.ToArray());
+    }
+
+    [Test]
+    public async Task GetRangeAsync_WhenStartExceedsFileSize_ShouldReturnInvalid()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream([1, 2, 3]);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetRangeAsync(blobId, 100, 200);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+    }
+
+    [Test]
+    public async Task GetRangeAsync_WhenBlobDoesNotExist_ShouldReturnNotFound()
+    {
+        var result = await sut.GetRangeAsync(Guid.NewGuid(), 0, 10);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenBlobExists_ShouldRemoveFile()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream([1, 2, 3]);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.DeleteAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        File.Exists(sut.GetBlobPath(blobId)).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenBlobDoesNotExist_ShouldReturnSuccess()
+    {
+        var result = await sut.DeleteAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.Ok);
+    }
+
+    [Test]
+    public async Task DeleteAsync_ShouldCleanUpEmptyShardDirectory()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream([1]);
+        await sut.SaveAsync(input, blobId);
+        var shardDir = Path.GetDirectoryName(sut.GetBlobPath(blobId))!;
+
+        await sut.DeleteAsync(blobId);
+
+        Directory.Exists(shardDir).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetSizeAsync_WhenBlobExists_ShouldReturnCorrectSize()
+    {
+        var blobId = Guid.NewGuid();
+        var data = new byte[1024];
+        Random.Shared.NextBytes(data);
+        using var input = new MemoryStream(data);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.GetSizeAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(1024);
+    }
+
+    [Test]
+    public async Task GetSizeAsync_WhenBlobDoesNotExist_ShouldReturnNotFound()
+    {
+        var result = await sut.GetSizeAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Test]
+    public async Task ExistsAsync_WhenBlobExists_ShouldReturnTrue()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream([1]);
+        await sut.SaveAsync(input, blobId);
+
+        var result = await sut.ExistsAsync(blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WhenBlobDoesNotExist_ShouldReturnFalse()
+    {
+        var result = await sut.ExistsAsync(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ListAsync_ShouldReturnAllBlobIds()
+    {
+        var blobId1 = Guid.NewGuid();
+        var blobId2 = Guid.NewGuid();
+        using var s1 = new MemoryStream([1]);
+        using var s2 = new MemoryStream([2]);
+        await sut.SaveAsync(s1, blobId1);
+        await sut.SaveAsync(s2, blobId2);
+
+        var result = await sut.ListAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().HaveCount(2);
+        result.Value.Should().Contain(blobId1);
+        result.Value.Should().Contain(blobId2);
+    }
+
+    [Test]
+    public async Task ListAsync_WhenEmpty_ShouldReturnEmptyList()
+    {
+        var result = await sut.ListAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ListAsync_WhenBasePathDoesNotExist_ShouldReturnEmptyList()
+    {
+        var nonExistentDir = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}");
+        var logger = Substitute.For<ILogger<FileSystemBlobStorageProvider>>();
+        var provider = new FileSystemBlobStorageProvider(nonExistentDir, logger);
+
+        var result = await provider.ListAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SaveAndGet_RoundTrip_ShouldPreserveContent()
+    {
+        var blobId = Guid.NewGuid();
+        var data = new byte[8192];
+        Random.Shared.NextBytes(data);
+        using var input = new MemoryStream(data);
+
+        await sut.SaveAsync(input, blobId);
+        var getResult = await sut.GetAsync(blobId);
+
+        await using var output = getResult.Value;
+        using var ms = new MemoryStream();
+        await output.CopyToAsync(ms);
+        ms.ToArray().Should().Equal(data);
+    }
+
+    [Test]
+    public async Task SaveAsync_WhenContentIsEmpty_ShouldSaveEmptyFile()
+    {
+        var blobId = Guid.NewGuid();
+        using var input = new MemoryStream();
+
+        var result = await sut.SaveAsync(input, blobId);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        var sizeResult = await sut.GetSizeAsync(blobId);
+        sizeResult.Value.Should().Be(0);
+    }
+}

--- a/backend/ShuKnow.Infrastructure.Tests/Services/S3BucketInitializationServiceTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/S3BucketInitializationServiceTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using ShuKnow.Application.Common;
+using ShuKnow.Infrastructure.Services;
+
+namespace ShuKnow.Infrastructure.Tests.Services;
+
+[TestFixture]
+public class S3BucketInitializationServiceTests
+{
+    private const string BucketName = "shuknow";
+
+    private IAmazonS3 s3Client = null!;
+    private ILogger<S3BucketInitializationService> logger = null!;
+    private S3BucketInitializationService sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        s3Client = Substitute.For<IAmazonS3>();
+        logger = Substitute.For<ILogger<S3BucketInitializationService>>();
+        var options = Options.Create(new S3BlobStorageOptions
+        {
+            BucketName = BucketName
+        });
+
+        sut = new S3BucketInitializationService(s3Client, options, logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (s3Client is IDisposable disposable)
+            disposable.Dispose();
+    }
+
+    [Test]
+    public async Task StartAsync_WhenBucketAlreadyExists_ShouldOnlyValidate()
+    {
+        s3Client.ListObjectsV2Async(Arg.Any<ListObjectsV2Request>(), Arg.Any<CancellationToken>())
+            .Returns(new ListObjectsV2Response());
+
+        await sut.StartAsync(CancellationToken.None);
+
+        await s3Client.Received(1).ListObjectsV2Async(
+            Arg.Is<ListObjectsV2Request>(request => request.BucketName == BucketName && request.MaxKeys == 1),
+            Arg.Any<CancellationToken>());
+        await s3Client.DidNotReceive().PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task StartAsync_WhenBucketIsMissing_ShouldCreateIt()
+    {
+        s3Client.ListObjectsV2Async(Arg.Any<ListObjectsV2Request>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ListObjectsV2Response>>(_ => throw new AmazonS3Exception("missing")
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                ErrorCode = "NoSuchBucket"
+            });
+        s3Client.PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PutBucketResponse());
+
+        await sut.StartAsync(CancellationToken.None);
+
+        await s3Client.Received(1).PutBucketAsync(
+            Arg.Is<PutBucketRequest>(request => request.BucketName == BucketName),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public void StartAsync_WhenValidationFailsForAnotherReason_ShouldThrowClearConfigurationError()
+    {
+        s3Client.ListObjectsV2Async(Arg.Any<ListObjectsV2Request>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ListObjectsV2Response>>(_ => throw new AmazonS3Exception("denied")
+            {
+                StatusCode = HttpStatusCode.Forbidden
+            });
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"Failed to initialize S3 bucket '{BucketName}'.*");
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -117,6 +117,8 @@ public static class ServiceCollectionExtensions
 
                 return new AmazonS3Client(credentials, config);
             });
+
+            services.AddHostedService<S3BucketInitializationService>();
         }
 
         services.AddScoped<IBlobOrphanCleanupRunner, BlobOrphanCleanupRunner>();

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -77,14 +77,14 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IJwtService, JwtService>();
         services.AddScoped<IUnitOfWork, PostgresUnitOfWork>();
         services.AddScoped<IAiService, AiService>();
-        services.AddScoped<IBlobStorageService, BlobStorageService>();
+        services.AddSingleton<IBlobStorageService, BlobStorageService>();
         services.AddScoped<IEncryptionService, EncryptionService>();
     }
 
     private static void AddBlobStorage(this IServiceCollection services, BlobStorageOptions blobStorageOptions,
         FileSystemBlobStorageOptions fileSystemOptions, S3BlobStorageOptions s3Options)
     {
-        services.AddScoped<IBlobStorageProvider>(serviceProvider =>
+        services.AddSingleton<IBlobStorageProvider>(serviceProvider =>
         {
             if (blobStorageOptions.UsesFileSystem)
             {
@@ -101,7 +101,7 @@ public static class ServiceCollectionExtensions
         });
         if (blobStorageOptions.UsesS3)
         {
-            services.AddScoped<IAmazonS3>(_ =>
+            services.AddSingleton<IAmazonS3>(_ =>
             {
                 var credentials = new BasicAWSCredentials(s3Options.AccessKey, s3Options.SecretKey);
                 var config = new AmazonS3Config

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -1,9 +1,12 @@
+using System.ComponentModel.DataAnnotations;
 using Amazon.Runtime;
 using Amazon.S3;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ShuKnow.Application.Common;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Domain.Repositories;
@@ -18,54 +21,22 @@ public static class ServiceCollectionExtensions
 {
     public static void AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
-        var encryptionOptions = configuration.GetEncryptionOptions();
-        var blobStorageOptions = configuration.GetBlobStorageOptions();
-        var fileSystemOptions = configuration.GetOptionalFileSystemBlobStorageOptions();
-        var s3Options = configuration.GetOptionalS3BlobStorageOptions();
-        var orphanCleanupOptions = configuration.GetOrphanCleanupOptions().Validate();
+        services.AddInfrastructureOptions();
+        services.AddPostgres(configuration);
+        services.AddBlobStorage(configuration);
+        services.AddServices();
+        services.AddRepositories();
+        services.AddHostedService<BlobOrphanCleanupService>();
+    }
 
-        if (blobStorageOptions.UsesFileSystem)
-            fileSystemOptions.Validate();
-        else
-            s3Options.Validate();
-
+    private static void AddPostgres(this IServiceCollection services, IConfiguration configuration)
+    {
         services.AddDbContext<AppDbContext>((_, options) =>
         {
             var connectionString = configuration.GetConnectionString("Postgres");
             options
                 .UseNpgsql(connectionString, builder => builder.EnableRetryOnFailure())
                 .UseSnakeCaseNamingConvention();
-        });
-
-        services.ConfigureOptions(
-            encryptionOptions, blobStorageOptions, fileSystemOptions, s3Options, orphanCleanupOptions);
-
-        services.AddBlobStorage(blobStorageOptions, fileSystemOptions, s3Options);
-        services.AddServices();
-        services.AddRepositories();
-        services.AddHostedService<BlobOrphanCleanupService>();
-    }
-
-    private static void ConfigureOptions(this IServiceCollection services, EncryptionOptions encryptionOptions,
-        BlobStorageOptions blobStorageOptions, FileSystemBlobStorageOptions fileSystemOptions,
-        S3BlobStorageOptions s3Options, OrphanCleanupOptions orphanCleanupOptions)
-    {
-        services.Configure<EncryptionOptions>(o => o.Key = encryptionOptions.Key);
-        services.Configure<BlobStorageOptions>(o => o.Provider = blobStorageOptions.Provider);
-        services.Configure<FileSystemBlobStorageOptions>(o => o.BasePath = fileSystemOptions.BasePath);
-        services.Configure<S3BlobStorageOptions>(o =>
-        {
-            o.ServiceUrl = s3Options.ServiceUrl;
-            o.AccessKey = s3Options.AccessKey;
-            o.SecretKey = s3Options.SecretKey;
-            o.BucketName = s3Options.BucketName;
-            o.Prefix = s3Options.Prefix;
-            o.ForcePathStyle = s3Options.ForcePathStyle;
-        });
-        services.Configure<OrphanCleanupOptions>(o =>
-        {
-            o.IntervalHours = orphanCleanupOptions.IntervalHours;
-            o.GracePeriodMinutes = orphanCleanupOptions.GracePeriodMinutes;
         });
     }
 
@@ -79,49 +50,68 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAiService, AiService>();
         services.AddSingleton<IBlobStorageService, BlobStorageService>();
         services.AddSingleton<BlobDeletionQueue>();
-        services.AddSingleton<IBlobDeletionQueue>(serviceProvider =>
+        services.AddSingleton<IBlobDeletionQueue>(static serviceProvider =>
             serviceProvider.GetRequiredService<BlobDeletionQueue>());
-        services.AddHostedService(serviceProvider =>
+        services.AddSingleton<IHostedService>(static serviceProvider =>
             serviceProvider.GetRequiredService<BlobDeletionQueue>());
         services.AddScoped<IEncryptionService, EncryptionService>();
     }
 
-    private static void AddBlobStorage(this IServiceCollection services, BlobStorageOptions blobStorageOptions,
-        FileSystemBlobStorageOptions fileSystemOptions, S3BlobStorageOptions s3Options)
+    private static void AddBlobStorage(this IServiceCollection services, IConfiguration configuration)
+    {
+        var blobOptions = configuration.GetSection(BlobStorageOptions.SectionName).Get<BlobStorageOptions>()
+            ?? throw new InvalidOperationException($"{BlobStorageOptions.SectionName} section is not configured.");
+
+        if (blobOptions.UsesFileSystem)
+            services.AddFileSystemBlobStorage();
+        else if (blobOptions.UsesS3)
+            services.AddS3BlobStorage();
+        else
+            throw new InvalidOperationException(
+                $"{BlobStorageOptions.SectionName}:Provider must be '{BlobStorageOptions.FileSystemProvider}' or '{BlobStorageOptions.S3Provider}'.");
+
+        services.AddScoped<IBlobOrphanCleanupRunner, BlobOrphanCleanupRunner>();
+    }
+
+    private static void AddFileSystemBlobStorage(this IServiceCollection services)
     {
         services.AddSingleton<IBlobStorageProvider>(serviceProvider =>
         {
-            if (blobStorageOptions.UsesFileSystem)
+            var options = serviceProvider.GetRequiredService<IOptions<FileSystemBlobStorageOptions>>().Value;
+
+            return new FileSystemBlobStorageProvider(
+                options.BasePath,
+                serviceProvider.GetRequiredService<ILogger<FileSystemBlobStorageProvider>>());
+        });
+    }
+
+    private static void AddS3BlobStorage(this IServiceCollection services)
+    {
+        services.AddSingleton<IAmazonS3>(serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<S3BlobStorageOptions>>().Value;
+            var credentials = new BasicAWSCredentials(options.AccessKey, options.SecretKey);
+            var config = new AmazonS3Config
             {
-                return new FileSystemBlobStorageProvider(
-                    fileSystemOptions.BasePath,
-                    serviceProvider.GetRequiredService<ILogger<FileSystemBlobStorageProvider>>());
-            }
+                ServiceURL = options.ServiceUrl,
+                ForcePathStyle = options.ForcePathStyle
+            };
+
+            return new AmazonS3Client(credentials, config);
+        });
+
+        services.AddSingleton<IBlobStorageProvider>(serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<S3BlobStorageOptions>>().Value;
 
             return new S3BlobStorageProvider(
                 serviceProvider.GetRequiredService<IAmazonS3>(),
-                s3Options.BucketName,
-                s3Options.Prefix,
+                options.BucketName,
+                options.Prefix,
                 serviceProvider.GetRequiredService<ILogger<S3BlobStorageProvider>>());
         });
-        if (blobStorageOptions.UsesS3)
-        {
-            services.AddSingleton<IAmazonS3>(_ =>
-            {
-                var credentials = new BasicAWSCredentials(s3Options.AccessKey, s3Options.SecretKey);
-                var config = new AmazonS3Config
-                {
-                    ServiceURL = s3Options.ServiceUrl,
-                    ForcePathStyle = s3Options.ForcePathStyle
-                };
 
-                return new AmazonS3Client(credentials, config);
-            });
-
-            services.AddHostedService<S3BucketInitializationService>();
-        }
-
-        services.AddScoped<IBlobOrphanCleanupRunner, BlobOrphanCleanupRunner>();
+        services.AddHostedService<S3BucketInitializationService>();
     }
 
     private static void AddRepositories(this IServiceCollection services)
@@ -136,37 +126,76 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAttachmentRepository, AttachmentRepository>();
         services.AddScoped<ISettingsRepository, SettingsRepository>();
     }
-
-    private static EncryptionOptions GetEncryptionOptions(this IConfiguration configuration)
+    
+    private static void AddInfrastructureOptions(this IServiceCollection services)
     {
-        var section = configuration.GetSection(EncryptionOptions.SectionName);
-        var options = section.Get<EncryptionOptions>() ?? new EncryptionOptions();
-        return options.Validate();
+        services.AddSingleton<IValidateOptions<FileSystemBlobStorageOptions>, FileSystemBlobStorageOptionsValidation>();
+        services.AddSingleton<IValidateOptions<S3BlobStorageOptions>, S3BlobStorageOptionsValidation>();
+        
+        services.AddOptions<EncryptionOptions>()
+            .BindConfiguration(EncryptionOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<BlobStorageOptions>()
+            .BindConfiguration(BlobStorageOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<FileSystemBlobStorageOptions>()
+            .BindConfiguration(FileSystemBlobStorageOptions.SectionName)
+            .ValidateOnStart();
+
+        services.AddOptions<S3BlobStorageOptions>()
+            .BindConfiguration(S3BlobStorageOptions.SectionName)
+            .ValidateOnStart();
+
+        services.AddOptions<OrphanCleanupOptions>()
+            .BindConfiguration(OrphanCleanupOptions.SectionName)
+            .Validate(
+                options => options.GracePeriodMinutes <= options.IntervalHours * 60,
+                $"{OrphanCleanupOptions.SectionName}:GracePeriodMinutes must be less than or equal to IntervalHours * 60")
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
     }
 
-    private static BlobStorageOptions GetBlobStorageOptions(this IConfiguration configuration)
+    private sealed class FileSystemBlobStorageOptionsValidation(IOptions<BlobStorageOptions> blobStorageOptions)
+        : IValidateOptions<FileSystemBlobStorageOptions>
     {
-        var section = configuration.GetSection(BlobStorageOptions.SectionName);
-        var options = section.Get<BlobStorageOptions>() ?? new BlobStorageOptions();
-        return options.Validate();
+        public ValidateOptionsResult Validate(string? name, FileSystemBlobStorageOptions options)
+        {
+            return !blobStorageOptions.Value.UsesFileSystem
+                ? ValidateOptionsResult.Skip
+                : ValidateDataAnnotations(options);
+        }
     }
 
-    private static FileSystemBlobStorageOptions GetOptionalFileSystemBlobStorageOptions(
-        this IConfiguration configuration)
+    private sealed class S3BlobStorageOptionsValidation(IOptions<BlobStorageOptions> blobStorageOptions)
+        : IValidateOptions<S3BlobStorageOptions>
     {
-        var section = configuration.GetSection(FileSystemBlobStorageOptions.SectionName);
-        return section.Get<FileSystemBlobStorageOptions>() ?? new FileSystemBlobStorageOptions();
+        public ValidateOptionsResult Validate(string? name, S3BlobStorageOptions options)
+        {
+            return !blobStorageOptions.Value.UsesS3
+                ? ValidateOptionsResult.Skip
+                : ValidateDataAnnotations(options);
+        }
     }
 
-    private static S3BlobStorageOptions GetOptionalS3BlobStorageOptions(this IConfiguration configuration)
+    private static ValidateOptionsResult ValidateDataAnnotations<TOptions>(TOptions options)
+        where TOptions : class
     {
-        var section = configuration.GetSection(S3BlobStorageOptions.SectionName);
-        return section.Get<S3BlobStorageOptions>() ?? new S3BlobStorageOptions();
-    }
+        var validationResults = new List<ValidationResult>();
+        var validationContext = new ValidationContext(options);
 
-    private static OrphanCleanupOptions GetOrphanCleanupOptions(this IConfiguration configuration)
-    {
-        var section = configuration.GetSection(OrphanCleanupOptions.SectionName);
-        return section.Get<OrphanCleanupOptions>() ?? new OrphanCleanupOptions();
+        if (Validator.TryValidateObject(options, validationContext, validationResults, true))
+            return ValidateOptionsResult.Success;
+
+        var errors = validationResults
+            .Select(validationResult => validationResult.ErrorMessage)
+            .Where(error => !string.IsNullOrWhiteSpace(error))
+            .Cast<string>()
+            .ToArray();
+
+        return ValidateOptionsResult.Fail(errors);
     }
 }

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -24,9 +24,16 @@ public static class ServiceCollectionExtensions
         });
         
         services.Configure<EncryptionOptions>(o => o.Key = configuration.GetEncryptionOptions().Key);
+        services.Configure<OrphanCleanupOptions>(o =>
+        {
+            var cleanup = configuration.GetOrphanCleanupOptions();
+            o.IntervalHours = cleanup.IntervalHours;
+            o.GracePeriodMinutes = cleanup.GracePeriodMinutes;
+        });
 
         services.AddServices();
         services.AddRepositories();
+        services.AddHostedService<BlobOrphanCleanupService>();
     }
 
     private static void AddServices(this IServiceCollection services)
@@ -37,6 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUnitOfWork, PostgresUnitOfWork>();
         services.AddScoped<IAiService, AiService>();
         services.AddScoped<IBlobStorageService, BlobStorageService>();
+        services.AddScoped<IBlobOrphanCleanupRunner, BlobOrphanCleanupRunner>();
         services.AddScoped<IEncryptionService, EncryptionService>();
     }
 
@@ -58,5 +66,11 @@ public static class ServiceCollectionExtensions
         var section = configuration.GetSection(EncryptionOptions.SectionName);
         var options = section.Get<EncryptionOptions>() ?? new EncryptionOptions();
         return options.Validate();
+    }
+
+    private static OrphanCleanupOptions GetOrphanCleanupOptions(this IConfiguration configuration)
+    {
+        var section = configuration.GetSection(OrphanCleanupOptions.SectionName);
+        return section.Get<OrphanCleanupOptions>() ?? new OrphanCleanupOptions();
     }
 }

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -78,6 +78,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUnitOfWork, PostgresUnitOfWork>();
         services.AddScoped<IAiService, AiService>();
         services.AddSingleton<IBlobStorageService, BlobStorageService>();
+        services.AddSingleton<BlobDeletionQueue>();
+        services.AddSingleton<IBlobDeletionQueue>(serviceProvider =>
+            serviceProvider.GetRequiredService<BlobDeletionQueue>());
+        services.AddHostedService(serviceProvider =>
+            serviceProvider.GetRequiredService<BlobDeletionQueue>());
         services.AddScoped<IEncryptionService, EncryptionService>();
     }
 

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPasswordHasher, PasswordHasher>();
         services.AddScoped<IIdentityService, IdentityService>();
         services.AddScoped<IJwtService, JwtService>();
-        services.AddScoped<IUnitOfWork, UnitOfWork>();
+        services.AddScoped<IUnitOfWork, PostgresUnitOfWork>();
         services.AddScoped<IAiService, AiService>();
         services.AddScoped<IBlobStorageService, BlobStorageService>();
         services.AddScoped<IEncryptionService, EncryptionService>();

--- a/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
+using Amazon.Runtime;
+using Amazon.S3;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using ShuKnow.Application.Common;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Domain.Repositories;
@@ -15,6 +18,17 @@ public static class ServiceCollectionExtensions
 {
     public static void AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
+        var encryptionOptions = configuration.GetEncryptionOptions();
+        var blobStorageOptions = configuration.GetBlobStorageOptions();
+        var fileSystemOptions = configuration.GetOptionalFileSystemBlobStorageOptions();
+        var s3Options = configuration.GetOptionalS3BlobStorageOptions();
+        var orphanCleanupOptions = configuration.GetOrphanCleanupOptions().Validate();
+
+        if (blobStorageOptions.UsesFileSystem)
+            fileSystemOptions.Validate();
+        else
+            s3Options.Validate();
+
         services.AddDbContext<AppDbContext>((_, options) =>
         {
             var connectionString = configuration.GetConnectionString("Postgres");
@@ -22,21 +36,41 @@ public static class ServiceCollectionExtensions
                 .UseNpgsql(connectionString, builder => builder.EnableRetryOnFailure())
                 .UseSnakeCaseNamingConvention();
         });
-        
-        services.Configure<EncryptionOptions>(o => o.Key = configuration.GetEncryptionOptions().Key);
-        services.Configure<OrphanCleanupOptions>(o =>
-        {
-            var cleanup = configuration.GetOrphanCleanupOptions();
-            o.IntervalHours = cleanup.IntervalHours;
-            o.GracePeriodMinutes = cleanup.GracePeriodMinutes;
-        });
 
+        services.ConfigureOptions(
+            encryptionOptions, blobStorageOptions, fileSystemOptions, s3Options, orphanCleanupOptions);
+
+        services.AddBlobStorage(blobStorageOptions, fileSystemOptions, s3Options);
         services.AddServices();
         services.AddRepositories();
         services.AddHostedService<BlobOrphanCleanupService>();
     }
 
-    private static void AddServices(this IServiceCollection services)
+    private static void ConfigureOptions(this IServiceCollection services, EncryptionOptions encryptionOptions,
+        BlobStorageOptions blobStorageOptions, FileSystemBlobStorageOptions fileSystemOptions,
+        S3BlobStorageOptions s3Options, OrphanCleanupOptions orphanCleanupOptions)
+    {
+        services.Configure<EncryptionOptions>(o => o.Key = encryptionOptions.Key);
+        services.Configure<BlobStorageOptions>(o => o.Provider = blobStorageOptions.Provider);
+        services.Configure<FileSystemBlobStorageOptions>(o => o.BasePath = fileSystemOptions.BasePath);
+        services.Configure<S3BlobStorageOptions>(o =>
+        {
+            o.ServiceUrl = s3Options.ServiceUrl;
+            o.AccessKey = s3Options.AccessKey;
+            o.SecretKey = s3Options.SecretKey;
+            o.BucketName = s3Options.BucketName;
+            o.Prefix = s3Options.Prefix;
+            o.ForcePathStyle = s3Options.ForcePathStyle;
+        });
+        services.Configure<OrphanCleanupOptions>(o =>
+        {
+            o.IntervalHours = orphanCleanupOptions.IntervalHours;
+            o.GracePeriodMinutes = orphanCleanupOptions.GracePeriodMinutes;
+        });
+    }
+
+    private static void AddServices(
+        this IServiceCollection services)
     {
         services.AddScoped<IPasswordHasher, PasswordHasher>();
         services.AddScoped<IIdentityService, IdentityService>();
@@ -44,8 +78,43 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUnitOfWork, PostgresUnitOfWork>();
         services.AddScoped<IAiService, AiService>();
         services.AddScoped<IBlobStorageService, BlobStorageService>();
-        services.AddScoped<IBlobOrphanCleanupRunner, BlobOrphanCleanupRunner>();
         services.AddScoped<IEncryptionService, EncryptionService>();
+    }
+
+    private static void AddBlobStorage(this IServiceCollection services, BlobStorageOptions blobStorageOptions,
+        FileSystemBlobStorageOptions fileSystemOptions, S3BlobStorageOptions s3Options)
+    {
+        services.AddScoped<IBlobStorageProvider>(serviceProvider =>
+        {
+            if (blobStorageOptions.UsesFileSystem)
+            {
+                return new FileSystemBlobStorageProvider(
+                    fileSystemOptions.BasePath,
+                    serviceProvider.GetRequiredService<ILogger<FileSystemBlobStorageProvider>>());
+            }
+
+            return new S3BlobStorageProvider(
+                serviceProvider.GetRequiredService<IAmazonS3>(),
+                s3Options.BucketName,
+                s3Options.Prefix,
+                serviceProvider.GetRequiredService<ILogger<S3BlobStorageProvider>>());
+        });
+        if (blobStorageOptions.UsesS3)
+        {
+            services.AddScoped<IAmazonS3>(_ =>
+            {
+                var credentials = new BasicAWSCredentials(s3Options.AccessKey, s3Options.SecretKey);
+                var config = new AmazonS3Config
+                {
+                    ServiceURL = s3Options.ServiceUrl,
+                    ForcePathStyle = s3Options.ForcePathStyle
+                };
+
+                return new AmazonS3Client(credentials, config);
+            });
+        }
+
+        services.AddScoped<IBlobOrphanCleanupRunner, BlobOrphanCleanupRunner>();
     }
 
     private static void AddRepositories(this IServiceCollection services)
@@ -60,12 +129,32 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAttachmentRepository, AttachmentRepository>();
         services.AddScoped<ISettingsRepository, SettingsRepository>();
     }
-    
+
     private static EncryptionOptions GetEncryptionOptions(this IConfiguration configuration)
     {
         var section = configuration.GetSection(EncryptionOptions.SectionName);
         var options = section.Get<EncryptionOptions>() ?? new EncryptionOptions();
         return options.Validate();
+    }
+
+    private static BlobStorageOptions GetBlobStorageOptions(this IConfiguration configuration)
+    {
+        var section = configuration.GetSection(BlobStorageOptions.SectionName);
+        var options = section.Get<BlobStorageOptions>() ?? new BlobStorageOptions();
+        return options.Validate();
+    }
+
+    private static FileSystemBlobStorageOptions GetOptionalFileSystemBlobStorageOptions(
+        this IConfiguration configuration)
+    {
+        var section = configuration.GetSection(FileSystemBlobStorageOptions.SectionName);
+        return section.Get<FileSystemBlobStorageOptions>() ?? new FileSystemBlobStorageOptions();
+    }
+
+    private static S3BlobStorageOptions GetOptionalS3BlobStorageOptions(this IConfiguration configuration)
+    {
+        var section = configuration.GetSection(S3BlobStorageOptions.SectionName);
+        return section.Get<S3BlobStorageOptions>() ?? new S3BlobStorageOptions();
     }
 
     private static OrphanCleanupOptions GetOrphanCleanupOptions(this IConfiguration configuration)

--- a/backend/ShuKnow.Infrastructure/Interfaces/IBlobOrphanCleanupRunner.cs
+++ b/backend/ShuKnow.Infrastructure/Interfaces/IBlobOrphanCleanupRunner.cs
@@ -1,0 +1,6 @@
+namespace ShuKnow.Infrastructure.Interfaces;
+
+public interface IBlobOrphanCleanupRunner
+{
+    Task<int> RunCleanupAsync(CancellationToken ct);
+}

--- a/backend/ShuKnow.Infrastructure/Interfaces/IBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Interfaces/IBlobStorageProvider.cs
@@ -16,6 +16,6 @@ public interface IBlobStorageProvider
 
     Task<Result<bool>> ExistsAsync(Guid blobId, CancellationToken ct = default);
 
-    Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> ListWithTimestampsAsync(
+    IAsyncEnumerable<(Guid BlobId, DateTimeOffset CreatedAt)> StreamWithTimestampsAsync(
         CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Infrastructure/Interfaces/IBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Interfaces/IBlobStorageProvider.cs
@@ -1,0 +1,20 @@
+using Ardalis.Result;
+
+namespace ShuKnow.Infrastructure.Interfaces;
+
+public interface IBlobStorageProvider
+{
+    Task<Result> SaveAsync(Stream content, Guid blobId, CancellationToken ct = default);
+
+    Task<Result<Stream>> GetAsync(Guid blobId, CancellationToken ct = default);
+
+    Task<Result<Stream>> GetRangeAsync(Guid blobId, long rangeStart, long rangeEnd, CancellationToken ct = default);
+
+    Task<Result> DeleteAsync(Guid blobId, CancellationToken ct = default);
+
+    Task<Result<long>> GetSizeAsync(Guid blobId, CancellationToken ct = default);
+
+    Task<Result<bool>> ExistsAsync(Guid blobId, CancellationToken ct = default);
+
+    Task<Result<IReadOnlyList<Guid>>> ListAsync(CancellationToken ct = default);
+}

--- a/backend/ShuKnow.Infrastructure/Interfaces/IBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Interfaces/IBlobStorageProvider.cs
@@ -16,5 +16,6 @@ public interface IBlobStorageProvider
 
     Task<Result<bool>> ExistsAsync(Guid blobId, CancellationToken ct = default);
 
-    Task<Result<IReadOnlyList<Guid>>> ListAsync(CancellationToken ct = default);
+    Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> ListWithTimestampsAsync(
+        CancellationToken ct = default);
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/AttachmentRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/AttachmentRepository.cs
@@ -30,4 +30,9 @@ public class AttachmentRepository : IAttachmentRepository
     {
         throw new NotImplementedException();
     }
+
+    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/AttachmentRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/AttachmentRepository.cs
@@ -31,7 +31,9 @@ public class AttachmentRepository : IAttachmentRepository
         throw new NotImplementedException();
     }
 
-    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default)
+    public Task<Result<IReadOnlySet<Guid>>> GetExistingBlobIdsAsync(
+        IReadOnlyCollection<Guid> blobIds,
+        CancellationToken ct = default)
     {
         throw new NotImplementedException();
     }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/AttachmentRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/AttachmentRepository.cs
@@ -31,7 +31,7 @@ public class AttachmentRepository : IAttachmentRepository
         throw new NotImplementedException();
     }
 
-    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync()
+    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default)
     {
         throw new NotImplementedException();
     }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/FileRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/FileRepository.cs
@@ -57,7 +57,9 @@ public class FileRepository : IFileRepository
         throw new NotImplementedException();
     }
 
-    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default)
+    public Task<Result<IReadOnlySet<Guid>>> GetExistingBlobIdsAsync(
+        IReadOnlyCollection<Guid> blobIds,
+        CancellationToken ct = default)
     {
         throw new NotImplementedException();
     }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/FileRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/FileRepository.cs
@@ -57,7 +57,7 @@ public class FileRepository : IFileRepository
         throw new NotImplementedException();
     }
 
-    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync()
+    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync(CancellationToken ct = default)
     {
         throw new NotImplementedException();
     }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/FileRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/FileRepository.cs
@@ -56,4 +56,9 @@ public class FileRepository : IFileRepository
     {
         throw new NotImplementedException();
     }
+
+    public Task<Result<IReadOnlySet<Guid>>> GetAllBlobIdsAsync()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/backend/ShuKnow.Infrastructure/Services/BlobDeletionQueue.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobDeletionQueue.cs
@@ -1,0 +1,47 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ShuKnow.Application.Interfaces;
+
+namespace ShuKnow.Infrastructure.Services;
+
+public sealed class BlobDeletionQueue(
+    IBlobStorageService blobStorageService,
+    ILogger<BlobDeletionQueue> logger) : BackgroundService, IBlobDeletionQueue
+{
+    private readonly Channel<Guid> queue = Channel.CreateBounded<Guid>(new BoundedChannelOptions(256)
+    {
+        FullMode = BoundedChannelFullMode.Wait,
+        SingleReader = true,
+        SingleWriter = false
+    });
+
+    public ValueTask EnqueueDeleteAsync(Guid blobId)
+        => queue.Writer.WriteAsync(blobId);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var blobId in queue.Reader.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                var result = await blobStorageService.DeleteAsync(blobId, stoppingToken);
+                if (result.IsSuccess) 
+                    continue;
+                
+                logger.LogWarning(
+                    "Best-effort blob cleanup failed for {BlobId}: {Errors}",
+                    blobId,
+                    string.Join(", ", result.Errors));
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Best-effort blob cleanup failed for {BlobId}", blobId);
+            }
+        }
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupRunner.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupRunner.cs
@@ -1,0 +1,80 @@
+using Ardalis.Result;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ShuKnow.Application.Common;
+using ShuKnow.Domain.Repositories;
+using ShuKnow.Infrastructure.Interfaces;
+
+namespace ShuKnow.Infrastructure.Services;
+
+public class BlobOrphanCleanupRunner(
+    IBlobStorageProvider provider,
+    IFileRepository fileRepository,
+    IAttachmentRepository attachmentRepository,
+    IOptions<OrphanCleanupOptions> options,
+    ILogger<BlobOrphanCleanupRunner> logger) : IBlobOrphanCleanupRunner
+{
+    public async Task<int> RunCleanupAsync(CancellationToken ct)
+    {
+        var blobsResult = await provider.ListWithTimestampsAsync(ct);
+        if (!blobsResult.IsSuccess)
+        {
+            logger.LogWarning("Failed to list blobs: {Errors}", string.Join("; ", blobsResult.Errors));
+            return 0;
+        }
+
+        if (blobsResult.Value.Count == 0)
+            return 0;
+
+        var referencedResult = await GetReferencedBlobIdsAsync();
+        if (!referencedResult.IsSuccess)
+            return 0;
+
+        var cutoff = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(options.Value.GracePeriodMinutes);
+        var orphans = FindOrphans(blobsResult.Value, referencedResult.Value, cutoff);
+
+        return await DeleteOrphansAsync(orphans, ct);
+    }
+
+    private async Task<Result<HashSet<Guid>>> GetReferencedBlobIdsAsync()
+    {
+        var fileBlobIdsResult = await fileRepository.GetAllBlobIdsAsync();
+        var attachmentBlobIdsResult = await attachmentRepository.GetAllBlobIdsAsync();
+
+        if (!fileBlobIdsResult.IsSuccess || !attachmentBlobIdsResult.IsSuccess)
+        {
+            logger.LogWarning("Failed to query referenced blob IDs from database");
+            return Result<HashSet<Guid>>.Error("Failed to query referenced blob IDs");
+        }
+
+        var referenced = new HashSet<Guid>(fileBlobIdsResult.Value);
+        referenced.UnionWith(attachmentBlobIdsResult.Value);
+        return referenced;
+    }
+
+    private static List<Guid> FindOrphans(
+        IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)> blobs,
+        HashSet<Guid> referencedBlobIds,
+        DateTimeOffset cutoff)
+    {
+        return blobs
+            .Where(b => b.CreatedAt < cutoff && !referencedBlobIds.Contains(b.BlobId))
+            .Select(b => b.BlobId)
+            .ToList();
+    }
+
+    private async Task<int> DeleteOrphansAsync(List<Guid> orphans, CancellationToken ct)
+    {
+        var deleted = 0;
+        foreach (var orphanId in orphans)
+        {
+            var deleteResult = await provider.DeleteAsync(orphanId, ct);
+            if (deleteResult.IsSuccess)
+                deleted++;
+            else
+                logger.LogWarning("Failed to delete orphan blob {BlobId}", orphanId);
+        }
+
+        return deleted;
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupRunner.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupRunner.cs
@@ -14,36 +14,63 @@ public class BlobOrphanCleanupRunner(
     IOptions<OrphanCleanupOptions> options,
     ILogger<BlobOrphanCleanupRunner> logger) : IBlobOrphanCleanupRunner
 {
+    private const int CandidateBatchSize = 256;
+
     public async Task<int> RunCleanupAsync(CancellationToken ct)
     {
-        var blobsResult = await provider.ListWithTimestampsAsync(ct);
-        if (!blobsResult.IsSuccess)
-        {
-            logger.LogWarning("Failed to list blobs: {Errors}", string.Join("; ", blobsResult.Errors));
-            return 0;
-        }
-
-        if (blobsResult.Value.Count == 0)
-            return 0;
-
-        var referencedResult = await GetReferencedBlobIdsAsync(ct);
-        if (!referencedResult.IsSuccess)
-            return 0;
-
         var cutoff = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(options.Value.GracePeriodMinutes);
-        var orphans = FindOrphans(blobsResult.Value, referencedResult.Value, cutoff);
+        var candidates = new List<Guid>(CandidateBatchSize);
+        var deleted = 0;
 
-        return await DeleteOrphansAsync(orphans, ct);
+        try
+        {
+            await foreach (var blob in provider.StreamWithTimestampsAsync(ct))
+            {
+                if (blob.CreatedAt >= cutoff)
+                    continue;
+
+                candidates.Add(blob.BlobId);
+                if (candidates.Count < CandidateBatchSize)
+                    continue;
+
+                var deleteBatchResult = await DeleteUnreferencedBatchAsync(candidates, ct);
+                if (!deleteBatchResult.IsSuccess)
+                    return deleted;
+
+                deleted += deleteBatchResult.Value;
+                candidates.Clear();
+            }
+
+            if (candidates.Count == 0)
+                return deleted;
+
+            var finalBatchResult = await DeleteUnreferencedBatchAsync(candidates, ct);
+            if (!finalBatchResult.IsSuccess)
+                return deleted;
+
+            return deleted + finalBatchResult.Value;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to stream blobs for orphan cleanup");
+            return deleted;
+        }
     }
 
-    private async Task<Result<HashSet<Guid>>> GetReferencedBlobIdsAsync(CancellationToken ct)
+    private async Task<Result<HashSet<Guid>>> GetReferencedBlobIdsAsync(
+        IReadOnlyCollection<Guid> candidateBlobIds,
+        CancellationToken ct)
     {
-        var fileBlobIdsResult = await fileRepository.GetAllBlobIdsAsync(ct);
-        var attachmentBlobIdsResult = await attachmentRepository.GetAllBlobIdsAsync(ct);
+        var fileBlobIdsResult = await fileRepository.GetExistingBlobIdsAsync(candidateBlobIds, ct);
+        var attachmentBlobIdsResult = await attachmentRepository.GetExistingBlobIdsAsync(candidateBlobIds, ct);
 
         if (!fileBlobIdsResult.IsSuccess || !attachmentBlobIdsResult.IsSuccess)
         {
-            logger.LogWarning("Failed to query referenced blob IDs from database");
+            logger.LogWarning("Failed to query referenced blob IDs from database for a candidate batch");
             return Result<HashSet<Guid>>.Error("Failed to query referenced blob IDs");
         }
 
@@ -52,29 +79,27 @@ public class BlobOrphanCleanupRunner(
         return referenced;
     }
 
-    private static List<Guid> FindOrphans(
-        IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)> blobs,
-        HashSet<Guid> referencedBlobIds,
-        DateTimeOffset cutoff)
+    private async Task<Result<int>> DeleteUnreferencedBatchAsync(
+        IReadOnlyList<Guid> candidateBlobIds,
+        CancellationToken ct)
     {
-        return blobs
-            .Where(b => b.CreatedAt < cutoff && !referencedBlobIds.Contains(b.BlobId))
-            .Select(b => b.BlobId)
-            .ToList();
-    }
+        var referencedResult = await GetReferencedBlobIdsAsync(candidateBlobIds, ct);
+        if (!referencedResult.IsSuccess)
+            return Result<int>.Error("Failed to query referenced blob IDs");
 
-    private async Task<int> DeleteOrphansAsync(List<Guid> orphans, CancellationToken ct)
-    {
         var deleted = 0;
-        foreach (var orphanId in orphans)
+        foreach (var blobId in candidateBlobIds)
         {
-            var deleteResult = await provider.DeleteAsync(orphanId, ct);
+            if (referencedResult.Value.Contains(blobId))
+                continue;
+
+            var deleteResult = await provider.DeleteAsync(blobId, ct);
             if (deleteResult.IsSuccess)
                 deleted++;
             else
-                logger.LogWarning("Failed to delete orphan blob {BlobId}", orphanId);
+                logger.LogWarning("Failed to delete orphan blob {BlobId}", blobId);
         }
 
-        return deleted;
+        return Result.Success(deleted);
     }
 }

--- a/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupRunner.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupRunner.cs
@@ -26,7 +26,7 @@ public class BlobOrphanCleanupRunner(
         if (blobsResult.Value.Count == 0)
             return 0;
 
-        var referencedResult = await GetReferencedBlobIdsAsync();
+        var referencedResult = await GetReferencedBlobIdsAsync(ct);
         if (!referencedResult.IsSuccess)
             return 0;
 
@@ -36,10 +36,10 @@ public class BlobOrphanCleanupRunner(
         return await DeleteOrphansAsync(orphans, ct);
     }
 
-    private async Task<Result<HashSet<Guid>>> GetReferencedBlobIdsAsync()
+    private async Task<Result<HashSet<Guid>>> GetReferencedBlobIdsAsync(CancellationToken ct)
     {
-        var fileBlobIdsResult = await fileRepository.GetAllBlobIdsAsync();
-        var attachmentBlobIdsResult = await attachmentRepository.GetAllBlobIdsAsync();
+        var fileBlobIdsResult = await fileRepository.GetAllBlobIdsAsync(ct);
+        var attachmentBlobIdsResult = await attachmentRepository.GetAllBlobIdsAsync(ct);
 
         if (!fileBlobIdsResult.IsSuccess || !attachmentBlobIdsResult.IsSuccess)
         {

--- a/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupService.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ShuKnow.Application.Common;
+using ShuKnow.Infrastructure.Interfaces;
+
+namespace ShuKnow.Infrastructure.Services;
+
+public class BlobOrphanCleanupService(
+    IServiceScopeFactory scopeFactory,
+    IOptions<OrphanCleanupOptions> options,
+    ILogger<BlobOrphanCleanupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromHours(options.Value.IntervalHours);
+        logger.LogInformation(
+            "Blob orphan cleanup started. Interval: {Interval}, GracePeriod: {GracePeriod}m",
+            interval, options.Value.GracePeriodMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(interval, stoppingToken);
+
+            try
+            {
+                var deleted = await RunCleanupAsync(stoppingToken);
+                if (deleted > 0)
+                    logger.LogInformation("Orphan cleanup deleted {Count} blob(s)", deleted);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogError(ex, "Orphan cleanup cycle failed");
+            }
+        }
+    }
+
+    internal async Task<int> RunCleanupAsync(CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var runner = scope.ServiceProvider.GetRequiredService<IBlobOrphanCleanupRunner>();
+        return await runner.RunCleanupAsync(ct);
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobOrphanCleanupService.cs
@@ -21,8 +21,6 @@ public class BlobOrphanCleanupService(
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            await Task.Delay(interval, stoppingToken);
-
             try
             {
                 var deleted = await RunCleanupAsync(stoppingToken);
@@ -33,6 +31,8 @@ public class BlobOrphanCleanupService(
             {
                 logger.LogError(ex, "Orphan cleanup cycle failed");
             }
+
+            await Task.Delay(interval, stoppingToken);
         }
     }
 

--- a/backend/ShuKnow.Infrastructure/Services/BlobStorageService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobStorageService.cs
@@ -1,44 +1,24 @@
 using Ardalis.Result;
 using ShuKnow.Application.Interfaces;
-using File = ShuKnow.Domain.Entities.File;
+using ShuKnow.Infrastructure.Interfaces;
 
 namespace ShuKnow.Infrastructure.Services;
 
-public class BlobStorageService : IBlobStorageService
+public class BlobStorageService(IBlobStorageProvider provider) : IBlobStorageService
 {
-    public Task<Result> SaveAsync(Stream content, File file, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<Result> SaveAsync(Stream content, Guid blobId, CancellationToken ct = default)
+        => provider.SaveAsync(content, blobId, ct);
 
-    public Task<Result> SaveAsync(Stream content, Guid id, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<Result> ReplaceAsync(Stream content, File file, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<Result<Stream>> GetAsync(Guid fileId, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<Result<Stream>> GetAsync(Guid blobId, CancellationToken ct = default)
+        => provider.GetAsync(blobId, ct);
 
     public Task<Result<Stream>> GetRangeAsync(
-        Guid fileId, long rangeStart, long rangeEnd, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+        Guid blobId, long rangeStart, long rangeEnd, CancellationToken ct = default)
+        => provider.GetRangeAsync(blobId, rangeStart, rangeEnd, ct);
 
-    public Task<Result> DeleteAsync(Guid fileId, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<Result> DeleteAsync(Guid blobId, CancellationToken ct = default)
+        => provider.DeleteAsync(blobId, ct);
 
-    public Task<Result<long>> GetSizeAsync(Guid fileId, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<Result<long>> GetSizeAsync(Guid blobId, CancellationToken ct = default)
+        => provider.GetSizeAsync(blobId, ct);
 }

--- a/backend/ShuKnow.Infrastructure/Services/BlobStorageService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobStorageService.cs
@@ -6,6 +6,8 @@ namespace ShuKnow.Infrastructure.Services;
 
 public class BlobStorageService(IBlobStorageProvider provider) : IBlobStorageService
 {
+    private const string InvalidRangeMessage = "Byte range must be non-negative and end must be greater than start.";
+
     public Task<Result> SaveAsync(Stream content, Guid blobId, CancellationToken ct = default)
         => provider.SaveAsync(content, blobId, ct);
 
@@ -14,7 +16,12 @@ public class BlobStorageService(IBlobStorageProvider provider) : IBlobStorageSer
 
     public Task<Result<Stream>> GetRangeAsync(
         Guid blobId, long rangeStart, long rangeEnd, CancellationToken ct = default)
-        => provider.GetRangeAsync(blobId, rangeStart, rangeEnd, ct);
+    {
+        if (rangeStart < 0 || rangeEnd <= rangeStart)
+            return Task.FromResult(Result<Stream>.Invalid(new ValidationError(InvalidRangeMessage)));
+
+        return provider.GetRangeAsync(blobId, rangeStart, rangeEnd, ct);
+    }
 
     public Task<Result> DeleteAsync(Guid blobId, CancellationToken ct = default)
         => provider.DeleteAsync(blobId, ct);

--- a/backend/ShuKnow.Infrastructure/Services/BlobStorageService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BlobStorageService.cs
@@ -4,7 +4,7 @@ using File = ShuKnow.Domain.Entities.File;
 
 namespace ShuKnow.Infrastructure.Services;
 
-internal class BlobStorageService : IBlobStorageService
+public class BlobStorageService : IBlobStorageService
 {
     public Task<Result> SaveAsync(Stream content, File file, CancellationToken ct = default)
     {

--- a/backend/ShuKnow.Infrastructure/Services/BoundedReadStream.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BoundedReadStream.cs
@@ -1,0 +1,70 @@
+namespace ShuKnow.Infrastructure.Services;
+
+public class BoundedReadStream(Stream inner, long length) : Stream
+{
+    private long remaining = length;
+
+    public override bool CanRead => inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => length;
+
+    public override long Position
+    {
+        get => length - remaining;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (remaining <= 0)
+            return 0;
+        
+        var toRead = (int)Math.Min(count, remaining);
+        var bytesRead = inner.Read(buffer, offset, toRead);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken ct)
+    {
+        if (remaining <= 0)
+            return 0;
+        
+        var toRead = (int)Math.Min(count, remaining);
+        var bytesRead = await inner.ReadAsync(buffer.AsMemory(offset, toRead), ct);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+    {
+        if (remaining <= 0) 
+            return 0;
+        
+        var toRead = (int)Math.Min(buffer.Length, remaining);
+        var bytesRead = await inner.ReadAsync(buffer[..toRead], ct);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+
+    public override void Flush() => inner.Flush();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) inner.Dispose();
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await inner.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Services/BoundedReadStream.cs
+++ b/backend/ShuKnow.Infrastructure/Services/BoundedReadStream.cs
@@ -64,7 +64,6 @@ public class BoundedReadStream(Stream inner, long length) : Stream
 
     public override async ValueTask DisposeAsync()
     {
-        await inner.DisposeAsync();
-        GC.SuppressFinalize(this);
+        await base.DisposeAsync();
     }
 }

--- a/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
@@ -1,0 +1,146 @@
+using Ardalis.Result;
+using Microsoft.Extensions.Logging;
+using ShuKnow.Infrastructure.Interfaces;
+
+namespace ShuKnow.Infrastructure.Services;
+
+public class FileSystemBlobStorageProvider(
+    string basePath,
+    ILogger<FileSystemBlobStorageProvider> logger) : IBlobStorageProvider
+{
+    private const int BufferSize = 81920;
+
+    public async Task<Result> SaveAsync(Stream content, Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var filePath = GetBlobPath(blobId);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+
+            await using var fileStream = new FileStream(
+                filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, BufferSize, useAsync: true);
+            await content.CopyToAsync(fileStream, ct);
+
+            return Result.Success();
+        }
+        catch (IOException ex) when (ex is not DirectoryNotFoundException)
+        {
+            logger.LogError(ex, "Failed to save blob {BlobId}", blobId);
+            return Result.Error($"Failed to save blob: {ex.Message}");
+        }
+    }
+
+    public Task<Result<Stream>> GetAsync(Guid blobId, CancellationToken ct = default)
+    {
+        var filePath = GetBlobPath(blobId);
+        if (!File.Exists(filePath))
+            return Task.FromResult(Result<Stream>.NotFound($"Blob {blobId} not found."));
+
+        var stream = new FileStream(
+            filePath, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize, useAsync: true);
+        return Task.FromResult(Result.Success<Stream>(stream));
+    }
+
+    public async Task<Result<Stream>> GetRangeAsync(
+        Guid blobId, long rangeStart, long rangeEnd, CancellationToken ct = default)
+    {
+        if (rangeStart < 0 || rangeEnd <= rangeStart)
+            return Result<Stream>.Invalid(
+                new ValidationError($"Invalid byte range [{rangeStart}, {rangeEnd})."));
+
+        var filePath = GetBlobPath(blobId);
+        if (!File.Exists(filePath))
+            return Result<Stream>.NotFound($"Blob {blobId} not found.");
+
+        var fileStream = new FileStream(
+            filePath, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize, useAsync: true);
+
+        if (rangeStart >= fileStream.Length)
+        {
+            var blobSize = fileStream.Length;
+            await fileStream.DisposeAsync();
+            return Result<Stream>.Invalid(
+                new ValidationError($"Range start {rangeStart} exceeds blob size {blobSize}."));
+        }
+
+        var length = Math.Min(rangeEnd - rangeStart, fileStream.Length - rangeStart);
+
+        fileStream.Seek(rangeStart, SeekOrigin.Begin);
+        var boundedStream = new BoundedReadStream(fileStream, length);
+        return Result.Success<Stream>(boundedStream);
+    }
+
+    public Task<Result> DeleteAsync(Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var filePath = GetBlobPath(blobId);
+            if (!File.Exists(filePath))
+                return Task.FromResult(Result.Success());
+
+            File.Delete(filePath);
+            TryDeleteEmptyShardDirectory(blobId);
+            return Task.FromResult(Result.Success());
+        }
+        catch (IOException ex)
+        {
+            logger.LogError(ex, "Failed to delete blob {BlobId}", blobId);
+            return Task.FromResult(Result.Error($"Failed to delete blob: {ex.Message}"));
+        }
+    }
+
+    public Task<Result<long>> GetSizeAsync(Guid blobId, CancellationToken ct = default)
+    {
+        var filePath = GetBlobPath(blobId);
+        if (!File.Exists(filePath))
+            return Task.FromResult(Result<long>.NotFound($"Blob {blobId} not found."));
+
+        var info = new FileInfo(filePath);
+        return Task.FromResult(Result.Success(info.Length));
+    }
+
+    public Task<Result<bool>> ExistsAsync(Guid blobId, CancellationToken ct = default)
+    {
+        var filePath = GetBlobPath(blobId);
+        return Task.FromResult(Result.Success(File.Exists(filePath)));
+    }
+
+    public Task<Result<IReadOnlyList<Guid>>> ListAsync(CancellationToken ct = default)
+    {
+        var blobs = new List<Guid>();
+
+        if (!Directory.Exists(basePath))
+            return Task.FromResult(Result.Success<IReadOnlyList<Guid>>(blobs));
+
+        foreach (var shardDir in Directory.EnumerateDirectories(basePath))
+        foreach (var file in Directory.EnumerateFiles(shardDir))
+        {
+            var fileName = Path.GetFileName(file);
+            if (Guid.TryParse(fileName, out var blobId))
+                blobs.Add(blobId);
+        }
+
+        return Task.FromResult(Result.Success<IReadOnlyList<Guid>>(blobs));
+    }
+
+    public string GetBlobPath(Guid blobId)
+    {
+        var id = blobId.ToString("N");
+        var shard = id[..2];
+        return Path.Combine(basePath, shard, id);
+    }
+
+    private void TryDeleteEmptyShardDirectory(Guid blobId)
+    {
+        try
+        {
+            var shardDir = Path.GetDirectoryName(GetBlobPath(blobId))!;
+            if (Directory.Exists(shardDir) && !Directory.EnumerateFileSystemEntries(shardDir).Any())
+                Directory.Delete(shardDir);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup
+        }
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
@@ -166,15 +166,19 @@ public class FileSystemBlobStorageProvider(
 
     private void TryDeleteEmptyShardDirectory(Guid blobId)
     {
+        var shardDir = Path.GetDirectoryName(GetBlobPath(blobId))!;
+
         try
         {
-            var shardDir = Path.GetDirectoryName(GetBlobPath(blobId))!;
             if (Directory.Exists(shardDir) && !Directory.EnumerateFileSystemEntries(shardDir).Any())
                 Directory.Delete(shardDir);
         }
         catch (IOException)
         {
-            // Best-effort cleanup
+            logger.LogDebug(
+                "Best-effort cleanup failed for shard directory {ShardDir} after deleting blob {BlobId}",
+                shardDir,
+                blobId);
         }
     }
 }

--- a/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Ardalis.Result;
 using Microsoft.Extensions.Logging;
 using ShuKnow.Infrastructure.Interfaces;
@@ -105,23 +107,43 @@ public class FileSystemBlobStorageProvider(
         return Task.FromResult(Result.Success(File.Exists(filePath)));
     }
 
-    public Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> ListWithTimestampsAsync(
-        CancellationToken ct = default)
+    public async IAsyncEnumerable<(Guid BlobId, DateTimeOffset CreatedAt)> StreamWithTimestampsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var blobs = new List<(Guid BlobId, DateTimeOffset CreatedAt)>();
-
         if (!Directory.Exists(basePath))
-            return Task.FromResult(
-                Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs));
+            yield break;
 
-        foreach (var (blobId, filePath) in EnumerateBlobs())
+        var channel = Channel.CreateBounded<(Guid BlobId, DateTimeOffset CreatedAt)>(
+            new BoundedChannelOptions(256)
+            {
+                SingleReader = true,
+                SingleWriter = true
+            });
+
+        var producer = Task.Run(() =>
         {
-            var createdAt = new DateTimeOffset(File.GetCreationTimeUtc(filePath), TimeSpan.Zero);
-            blobs.Add((blobId, createdAt));
-        }
+            try
+            {
+                foreach (var (blobId, filePath) in EnumerateBlobs())
+                {
+                    ct.ThrowIfCancellationRequested();
 
-        return Task.FromResult(
-            Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs));
+                    var createdAt = new DateTimeOffset(File.GetCreationTimeUtc(filePath), TimeSpan.Zero);
+                    channel.Writer.WriteAsync((blobId, createdAt), ct).AsTask().GetAwaiter().GetResult();
+                }
+
+                channel.Writer.TryComplete();
+            }
+            catch (Exception ex)
+            {
+                channel.Writer.TryComplete(ex);
+            }
+        }, ct);
+
+        await foreach (var blob in channel.Reader.ReadAllAsync(ct))
+            yield return blob;
+
+        await producer;
     }
 
     public string GetBlobPath(Guid blobId)

--- a/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/FileSystemBlobStorageProvider.cs
@@ -105,22 +105,23 @@ public class FileSystemBlobStorageProvider(
         return Task.FromResult(Result.Success(File.Exists(filePath)));
     }
 
-    public Task<Result<IReadOnlyList<Guid>>> ListAsync(CancellationToken ct = default)
+    public Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> ListWithTimestampsAsync(
+        CancellationToken ct = default)
     {
-        var blobs = new List<Guid>();
+        var blobs = new List<(Guid BlobId, DateTimeOffset CreatedAt)>();
 
         if (!Directory.Exists(basePath))
-            return Task.FromResult(Result.Success<IReadOnlyList<Guid>>(blobs));
+            return Task.FromResult(
+                Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs));
 
-        foreach (var shardDir in Directory.EnumerateDirectories(basePath))
-        foreach (var file in Directory.EnumerateFiles(shardDir))
+        foreach (var (blobId, filePath) in EnumerateBlobs())
         {
-            var fileName = Path.GetFileName(file);
-            if (Guid.TryParse(fileName, out var blobId))
-                blobs.Add(blobId);
+            var createdAt = new DateTimeOffset(File.GetCreationTimeUtc(filePath), TimeSpan.Zero);
+            blobs.Add((blobId, createdAt));
         }
 
-        return Task.FromResult(Result.Success<IReadOnlyList<Guid>>(blobs));
+        return Task.FromResult(
+            Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs));
     }
 
     public string GetBlobPath(Guid blobId)
@@ -128,6 +129,17 @@ public class FileSystemBlobStorageProvider(
         var id = blobId.ToString("N");
         var shard = id[..2];
         return Path.Combine(basePath, shard, id);
+    }
+
+    private IEnumerable<(Guid BlobId, string FilePath)> EnumerateBlobs()
+    {
+        foreach (var shardDir in Directory.EnumerateDirectories(basePath))
+        foreach (var filePath in Directory.EnumerateFiles(shardDir))
+        {
+            var fileName = Path.GetFileName(filePath);
+            if (Guid.TryParse(fileName, out var blobId))
+                yield return (blobId, filePath);
+        }
     }
 
     private void TryDeleteEmptyShardDirectory(Guid blobId)

--- a/backend/ShuKnow.Infrastructure/Services/PostgresUnitOfWork.cs
+++ b/backend/ShuKnow.Infrastructure/Services/PostgresUnitOfWork.cs
@@ -7,7 +7,7 @@ using ShuKnow.Infrastructure.Persistent;
 
 namespace ShuKnow.Infrastructure.Services;
 
-public class UnitOfWork(AppDbContext context, ILogger<UnitOfWork> logger) : IUnitOfWork
+public class PostgresUnitOfWork(AppDbContext context, ILogger<PostgresUnitOfWork> logger) : IUnitOfWork
 {
     public async Task<Result> SaveChangesAsync()
     {

--- a/backend/ShuKnow.Infrastructure/Services/S3BlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/S3BlobStorageProvider.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Ardalis.Result;
+using Microsoft.Extensions.Logging;
+using ShuKnow.Infrastructure.Interfaces;
+
+namespace ShuKnow.Infrastructure.Services;
+
+public class S3BlobStorageProvider(
+    IAmazonS3 s3Client,
+    string bucketName,
+    string prefix,
+    ILogger<S3BlobStorageProvider> logger) : IBlobStorageProvider
+{
+    public async Task<Result> SaveAsync(Stream content, Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = GetObjectKey(blobId),
+                InputStream = content,
+                AutoCloseStream = false
+            };
+
+            await s3Client.PutObjectAsync(request, ct);
+            return Result.Success();
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to save blob {BlobId} to S3", blobId);
+            return Result.Error($"Failed to save blob to S3: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<Stream>> GetAsync(Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new GetObjectRequest
+            {
+                BucketName = bucketName,
+                Key = GetObjectKey(blobId)
+            };
+
+            var response = await s3Client.GetObjectAsync(request, ct);
+            return Result.Success(response.ResponseStream);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return Result<Stream>.NotFound($"Blob {blobId} not found.");
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to get blob {BlobId} from S3", blobId);
+            return Result<Stream>.Error($"Failed to get blob from S3: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<Stream>> GetRangeAsync(
+        Guid blobId, long rangeStart, long rangeEnd, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new GetObjectRequest
+            {
+                BucketName = bucketName,
+                Key = GetObjectKey(blobId),
+                ByteRange = new ByteRange(rangeStart, rangeEnd - 1)
+            };
+
+            var response = await s3Client.GetObjectAsync(request, ct);
+            return Result.Success(response.ResponseStream);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return Result<Stream>.NotFound($"Blob {blobId} not found.");
+        }
+        catch (AmazonS3Exception ex) when (
+            ex.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+        {
+            return Result<Stream>.Invalid(
+                new ValidationError($"Invalid byte range {rangeStart}-{rangeEnd} for blob {blobId}."));
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to get range of blob {BlobId} from S3", blobId);
+            return Result<Stream>.Error($"Failed to get blob range from S3: {ex.Message}");
+        }
+    }
+
+    public async Task<Result> DeleteAsync(Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new DeleteObjectRequest
+            {
+                BucketName = bucketName,
+                Key = GetObjectKey(blobId)
+            };
+
+            await s3Client.DeleteObjectAsync(request, ct);
+            return Result.Success();
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete blob {BlobId} from S3", blobId);
+            return Result.Error($"Failed to delete blob from S3: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<long>> GetSizeAsync(Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new GetObjectMetadataRequest
+            {
+                BucketName = bucketName,
+                Key = GetObjectKey(blobId)
+            };
+
+            var response = await s3Client.GetObjectMetadataAsync(request, ct);
+            return Result.Success(response.ContentLength);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return Result<long>.NotFound($"Blob {blobId} not found.");
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to get size of blob {BlobId} from S3", blobId);
+            return Result<long>.Error($"Failed to get blob size from S3: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<bool>> ExistsAsync(Guid blobId, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new GetObjectMetadataRequest
+            {
+                BucketName = bucketName,
+                Key = GetObjectKey(blobId)
+            };
+
+            await s3Client.GetObjectMetadataAsync(request, ct);
+            return Result.Success(true);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return Result.Success(false);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to check existence of blob {BlobId} in S3", blobId);
+            return Result<bool>.Error($"Failed to check blob existence in S3: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<IReadOnlyList<Guid>>> ListAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var blobs = new List<Guid>();
+            var request = new ListObjectsV2Request
+            {
+                BucketName = bucketName,
+                Prefix = string.IsNullOrEmpty(prefix) ? null : prefix + "/"
+            };
+
+            while (true)
+            {
+                var response = await s3Client.ListObjectsV2Async(request, ct);
+
+                foreach (var obj in response.S3Objects ?? [])
+                {
+                    var key = obj.Key;
+                    var fileName = key.Contains('/') ? key[(key.LastIndexOf('/') + 1)..] : key;
+                    if (Guid.TryParse(fileName, out var blobId))
+                        blobs.Add(blobId);
+                }
+
+                if (response.IsTruncated != true)
+                    break;
+
+                request.ContinuationToken = response.NextContinuationToken;
+            }
+            
+            return Result.Success<IReadOnlyList<Guid>>(blobs);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Failed to list blobs in S3");
+            return Result<IReadOnlyList<Guid>>.Error($"Failed to list blobs in S3: {ex.Message}");
+        }
+    }
+
+    public string GetObjectKey(Guid blobId)
+    {
+        var id = blobId.ToString("N");
+        return string.IsNullOrEmpty(prefix) ? id : $"{prefix}/{id}";
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Services/S3BlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/S3BlobStorageProvider.cs
@@ -159,41 +159,31 @@ public class S3BlobStorageProvider(
         }
     }
 
-    public async Task<Result<IReadOnlyList<Guid>>> ListAsync(CancellationToken ct = default)
+    public async Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> ListWithTimestampsAsync(
+        CancellationToken ct = default)
     {
         try
         {
-            var blobs = new List<Guid>();
-            var request = new ListObjectsV2Request
+            var blobs = new List<(Guid BlobId, DateTimeOffset CreatedAt)>();
+
+            await PaginateObjectsAsync(ct, obj =>
             {
-                BucketName = bucketName,
-                Prefix = string.IsNullOrEmpty(prefix) ? null : prefix + "/"
-            };
+                if (!TryParseBlobId(obj.Key, out var blobId)) 
+                    return;
+                
+                var createdAt = obj.LastModified.HasValue
+                    ? new DateTimeOffset(obj.LastModified.Value, TimeSpan.Zero)
+                    : DateTimeOffset.UtcNow;
+                blobs.Add((blobId, createdAt));
+            });
 
-            while (true)
-            {
-                var response = await s3Client.ListObjectsV2Async(request, ct);
-
-                foreach (var obj in response.S3Objects ?? [])
-                {
-                    var key = obj.Key;
-                    var fileName = key.Contains('/') ? key[(key.LastIndexOf('/') + 1)..] : key;
-                    if (Guid.TryParse(fileName, out var blobId))
-                        blobs.Add(blobId);
-                }
-
-                if (response.IsTruncated != true)
-                    break;
-
-                request.ContinuationToken = response.NextContinuationToken;
-            }
-            
-            return Result.Success<IReadOnlyList<Guid>>(blobs);
+            return Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs);
         }
         catch (AmazonS3Exception ex)
         {
-            logger.LogError(ex, "Failed to list blobs in S3");
-            return Result<IReadOnlyList<Guid>>.Error($"Failed to list blobs in S3: {ex.Message}");
+            logger.LogError(ex, "Failed to list blobs with timestamps in S3");
+            return Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>.Error(
+                $"Failed to list blobs in S3: {ex.Message}");
         }
     }
 
@@ -201,5 +191,33 @@ public class S3BlobStorageProvider(
     {
         var id = blobId.ToString("N");
         return string.IsNullOrEmpty(prefix) ? id : $"{prefix}/{id}";
+    }
+
+    private async Task PaginateObjectsAsync(CancellationToken ct, Action<S3Object> onObject)
+    {
+        var request = new ListObjectsV2Request
+        {
+            BucketName = bucketName,
+            Prefix = string.IsNullOrEmpty(prefix) ? null : prefix + "/"
+        };
+
+        while (true)
+        {
+            var response = await s3Client.ListObjectsV2Async(request, ct);
+
+            foreach (var obj in response.S3Objects ?? [])
+                onObject(obj);
+
+            if (response.IsTruncated != true)
+                break;
+
+            request.ContinuationToken = response.NextContinuationToken;
+        }
+    }
+
+    private static bool TryParseBlobId(string key, out Guid blobId)
+    {
+        var fileName = key.Contains('/') ? key[(key.LastIndexOf('/') + 1)..] : key;
+        return Guid.TryParse(fileName, out blobId);
     }
 }

--- a/backend/ShuKnow.Infrastructure/Services/S3BlobStorageProvider.cs
+++ b/backend/ShuKnow.Infrastructure/Services/S3BlobStorageProvider.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Runtime.CompilerServices;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Ardalis.Result;
@@ -159,41 +160,8 @@ public class S3BlobStorageProvider(
         }
     }
 
-    public async Task<Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>> ListWithTimestampsAsync(
-        CancellationToken ct = default)
-    {
-        try
-        {
-            var blobs = new List<(Guid BlobId, DateTimeOffset CreatedAt)>();
-
-            await PaginateObjectsAsync(ct, obj =>
-            {
-                if (!TryParseBlobId(obj.Key, out var blobId)) 
-                    return;
-                
-                var createdAt = obj.LastModified.HasValue
-                    ? new DateTimeOffset(obj.LastModified.Value, TimeSpan.Zero)
-                    : DateTimeOffset.UtcNow;
-                blobs.Add((blobId, createdAt));
-            });
-
-            return Result.Success<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>(blobs);
-        }
-        catch (AmazonS3Exception ex)
-        {
-            logger.LogError(ex, "Failed to list blobs with timestamps in S3");
-            return Result<IReadOnlyList<(Guid BlobId, DateTimeOffset CreatedAt)>>.Error(
-                $"Failed to list blobs in S3: {ex.Message}");
-        }
-    }
-
-    public string GetObjectKey(Guid blobId)
-    {
-        var id = blobId.ToString("N");
-        return string.IsNullOrEmpty(prefix) ? id : $"{prefix}/{id}";
-    }
-
-    private async Task PaginateObjectsAsync(CancellationToken ct, Action<S3Object> onObject)
+    public async IAsyncEnumerable<(Guid BlobId, DateTimeOffset CreatedAt)> StreamWithTimestampsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
         var request = new ListObjectsV2Request
         {
@@ -206,13 +174,27 @@ public class S3BlobStorageProvider(
             var response = await s3Client.ListObjectsV2Async(request, ct);
 
             foreach (var obj in response.S3Objects ?? [])
-                onObject(obj);
+            {
+                if (!TryParseBlobId(obj.Key, out var blobId))
+                    continue;
+
+                var createdAt = obj.LastModified.HasValue
+                    ? new DateTimeOffset(obj.LastModified.Value, TimeSpan.Zero)
+                    : DateTimeOffset.UtcNow;
+                yield return (blobId, createdAt);
+            }
 
             if (response.IsTruncated != true)
-                break;
+                yield break;
 
             request.ContinuationToken = response.NextContinuationToken;
         }
+    }
+
+    public string GetObjectKey(Guid blobId)
+    {
+        var id = blobId.ToString("N");
+        return string.IsNullOrEmpty(prefix) ? id : $"{prefix}/{id}";
     }
 
     private static bool TryParseBlobId(string key, out Guid blobId)

--- a/backend/ShuKnow.Infrastructure/Services/S3BucketInitializationService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/S3BucketInitializationService.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ShuKnow.Application.Common;
+
+namespace ShuKnow.Infrastructure.Services;
+
+public sealed class S3BucketInitializationService(
+    IAmazonS3 s3Client,
+    IOptions<S3BlobStorageOptions> options,
+    ILogger<S3BucketInitializationService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var bucketName = options.Value.BucketName;
+
+        try
+        {
+            await EnsureBucketExistsAsync(bucketName, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to initialize S3 bucket '{bucketName}'. Check BlobStorage:S3 configuration and permissions.",
+                ex);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task EnsureBucketExistsAsync(string bucketName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await s3Client.ListObjectsV2Async(new ListObjectsV2Request
+            {
+                BucketName = bucketName,
+                MaxKeys = 1
+            }, cancellationToken);
+
+            logger.LogInformation("Validated S3 bucket {BucketName}", bucketName);
+        }
+        catch (AmazonS3Exception ex) when (IsMissingBucket(ex))
+        {
+            logger.LogInformation("S3 bucket {BucketName} was not found. Creating it.", bucketName);
+
+            await s3Client.PutBucketAsync(new PutBucketRequest
+            {
+                BucketName = bucketName
+            }, cancellationToken);
+
+            logger.LogInformation("Created S3 bucket {BucketName}", bucketName);
+        }
+    }
+
+    private static bool IsMissingBucket(AmazonS3Exception ex)
+    {
+        return ex.StatusCode == HttpStatusCode.NotFound
+            || string.Equals(ex.ErrorCode, "NoSuchBucket", StringComparison.Ordinal);
+    }
+}

--- a/backend/ShuKnow.Infrastructure/ShuKnow.Infrastructure.csproj
+++ b/backend/ShuKnow.Infrastructure/ShuKnow.Infrastructure.csproj
@@ -7,6 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="ShuKnow.Infrastructure.Tests" />
+      <InternalsVisibleTo Include="ShuKnow.Infrastructure.IntegrationTests" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="Ardalis.Result" Version="10.1.0" />
       <PackageReference Include="AWSSDK.S3" Version="4.0.19.4" />
       <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
@@ -14,6 +19,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.24" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     </ItemGroup>

--- a/backend/ShuKnow.Infrastructure/ShuKnow.Infrastructure.csproj
+++ b/backend/ShuKnow.Infrastructure/ShuKnow.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Ardalis.Result" Version="10.1.0" />
+      <PackageReference Include="AWSSDK.S3" Version="4.0.19.4" />
       <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.24" />

--- a/backend/ShuKnow.Infrastructure/ShuKnow.Infrastructure.csproj
+++ b/backend/ShuKnow.Infrastructure/ShuKnow.Infrastructure.csproj
@@ -20,6 +20,8 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.5" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     </ItemGroup>

--- a/backend/ShuKnow.WebAPI/Configuration/AuthCookieOptions.cs
+++ b/backend/ShuKnow.WebAPI/Configuration/AuthCookieOptions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Http;
 
 namespace ShuKnow.WebAPI.Configuration;
@@ -6,21 +7,17 @@ public class AuthCookieOptions
 {
     public const string SectionName = "AuthCookie";
 
+    [Required(AllowEmptyStrings = false)]
     public string Name { get; set; } = "token";
+
     public bool HttpOnly { get; set; } = true;
+
     public bool Secure { get; set; } = true;
+
     public bool IsEssential { get; set; } = true;
+
     public SameSiteMode SameSite { get; set; } = SameSiteMode.None;
+
+    [Range(1, int.MaxValue)]
     public int MaxAgeMinutes { get; set; } = 60;
-
-    public AuthCookieOptions Validate()
-    {
-        if (string.IsNullOrWhiteSpace(Name))
-            throw new InvalidOperationException($"{SectionName}:Name is not configured.");
-
-        if (MaxAgeMinutes <= 0)
-            throw new InvalidOperationException($"{SectionName}:MaxAgeMinutes must be greater than 0.");
-
-        return this;
-    }
 }

--- a/backend/ShuKnow.WebAPI/Configuration/ServiceCollectionExtensions.cs
+++ b/backend/ShuKnow.WebAPI/Configuration/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using Saunter;
@@ -22,6 +23,7 @@ public static class ServiceCollectionExtensions
 {
     public static void AddWeb(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddWebOptions();
         services.AddExceptionHandler<GlobalExceptionHandler>();
         services.AddProblemDetails();
         
@@ -43,7 +45,7 @@ public static class ServiceCollectionExtensions
             };
         });
 
-        services.AddAuth(configuration);
+        services.AddAuth();
 
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         services.AddScoped<ICurrentConnectionService, CurrentConnectionService>();
@@ -58,33 +60,18 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IHubFilter, ValidationHubFilter>();
     }
 
-    private static void AddAuth(this IServiceCollection services, IConfiguration configuration)
+    private static void AddAuth(this IServiceCollection services)
     {
-        var jwtOptions = configuration.GetJwtOptions();
-        var authCookieOptions = configuration.GetAuthCookieOptions();
-
-        services.Configure<JwtOptions>(options =>
-        {
-            options.Key = jwtOptions.Key;
-            options.ExpiresInMinutes = jwtOptions.ExpiresInMinutes;
-            options.Issuer = jwtOptions.Issuer;
-            options.Audience = jwtOptions.Audience;
-        });
-
-        services.Configure<AuthCookieOptions>(options =>
-        {
-            options.Name = authCookieOptions.Name;
-            options.HttpOnly = authCookieOptions.HttpOnly;
-            options.Secure = authCookieOptions.Secure;
-            options.IsEssential = authCookieOptions.IsEssential;
-            options.SameSite = authCookieOptions.SameSite;
-            options.MaxAgeMinutes = authCookieOptions.MaxAgeMinutes;
-        });
-
         services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
+            .AddJwtBearer();
+
+        services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+            .Configure<IOptions<JwtOptions>, IOptions<AuthCookieOptions>>((options, jwtOptionsAccessor, authCookieOptionsAccessor) =>
             {
+                var jwtOptions = jwtOptionsAccessor.Value;
+                var authCookieOptions = authCookieOptionsAccessor.Value;
+
                 options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
@@ -114,6 +101,19 @@ public static class ServiceCollectionExtensions
         services.AddAuthorization();
     }
 
+    private static void AddWebOptions(this IServiceCollection services)
+    {
+        services.AddOptions<JwtOptions>()
+            .BindConfiguration(JwtOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<AuthCookieOptions>()
+            .BindConfiguration(AuthCookieOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+    }
+
     private static void AddSwagger(this IServiceCollection services)
     {
         services.AddSwaggerGen(options =>
@@ -133,20 +133,5 @@ public static class ServiceCollectionExtensions
                 [new OpenApiSecuritySchemeReference("Bearer", document)] = []
             });
         });
-    }
-
-    private static JwtOptions GetJwtOptions(this IConfiguration configuration)
-    {
-        var jwtSection = configuration.GetSection(JwtOptions.SectionName);
-        var jwtOptions = jwtSection.Get<JwtOptions>() ?? new JwtOptions();
-        return jwtOptions.Validate();
-    }
-
-    private static AuthCookieOptions GetAuthCookieOptions(this IConfiguration configuration)
-    {
-        var authCookieSection = configuration.GetSection(AuthCookieOptions.SectionName);
-        var authCookieOptions = authCookieSection.Get<AuthCookieOptions>() ?? new AuthCookieOptions();
-
-        return authCookieOptions.Validate();
     }
 }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,29 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: shuknow
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    command: /data
+    environment:
+      RUSTFS_ADDRESS: ":9000"
+      RUSTFS_ACCESS_KEY: rustfsadmin
+      RUSTFS_SECRET_KEY: rustfsadmin
+      RUSTFS_CONSOLE_ENABLE: "true"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - rustfs-data:/data
+
+volumes:
+  postgres-data:
+  rustfs-data:

--- a/docs/SERVICES_ARCHITECTURE.md
+++ b/docs/SERVICES_ARCHITECTURE.md
@@ -87,7 +87,7 @@
 
 ### 1.5 IFileService
 
-**Назначение.** Управляет CRUD-операциями над метаданными файлов, загрузкой/скачиванием/заменой бинарного содержимого, обновлением текстового содержимого, переупорядочиванием и перемещением файлов между папками. Файлы имеют `SortOrder`, разделяющий общее пространство порядка с соседними папками, что обеспечивает смешанное перетаскивание файлов и папок. Проверяет уникальность имени в пределах папки, применяет ограничения по размеру и делегирует хранение бинарных данных абстракции blob-хранилища.
+**Назначение.** Управляет CRUD-операциями над метаданными файлов, загрузкой/скачиванием/заменой бинарного содержимого, обновлением текстового содержимого, переупорядочиванием и перемещением файлов между папками. Файлы имеют `SortOrder`, разделяющий общее пространство порядка с соседними папками, что обеспечивает смешанное перетаскивание файлов и папок. Проверяет уникальность имени в пределах папки, применяет ограничения по размеру и делегирует хранение бинарных данных абстракции blob-хранилища. Бинарное содержимое адресуется отдельным `File.BlobId`, а не ID сущности, поэтому потоки replace/delete опираются на orphan cleanup, а не на изменение blob-а "на месте".
 
 **Методы**
 
@@ -95,15 +95,15 @@
 |---|---|
 | `GetByIdAsync(fileId)` → `File` | Метаданные файла, включая имя папки-владельца. |
 | `ListByFolderAsync(folderId, page, pageSize)` → `(List<File> Files, int TotalCount)` | Пагинированный список файлов внутри папки по offset-схеме. |
-| `UploadAsync(folderId, file, stream)` → `File` | Сохраняет бинарное содержимое через `IBlobStorageService`, затем сохраняет предоставленную сущность метаданных файла. Проверяет уникальность имени и ограничение по размеру. |
-| `UpdateMetadataAsync(fileId, file)` → `File` | Обновляет изменяемые метаданные файла (имя/описание). Проверяет уникальность имени в текущей папке файла. |
-| `DeleteAsync(fileId)` | Удаляет запись метаданных и бинарный blob. |
+| `UploadAsync(file, stream)` → `File` | Назначает новый `BlobId`, сохраняет бинарное содержимое через `IBlobStorageService`, затем сохраняет сущность метаданных файла. Если DB commit завершается ошибкой, blob остаётся orphan и будет удалён GC. |
+| `UpdateMetadataAsync(file)` → `File` | Обновляет изменяемые метаданные файла (имя/описание). Проверяет уникальность имени в текущей папке файла. |
+| `DeleteAsync(fileId)` | Удаляет запись метаданных, коммитит это удаление, затем ставит best-effort очистку blob-а в `IBlobDeletionQueue`. |
 | `GetContentAsync(fileId, rangeStart?, rangeEnd?)` → `(Stream Content, string ContentType, long SizeBytes)` | Стримит бинарное содержимое. Возвращает content type и поддерживает HTTP Range для частичных загрузок. |
-| `ReplaceContentAsync(fileId, stream, contentType)` → `File` | Заменяет бинарный blob на месте. Метаданные (имя, описание) не меняются; обновляются `sizeBytes` и `contentType`. |
+| `ReplaceContentAsync(fileId, stream, contentType)` → `File` | Сохраняет новое содержимое под новым `BlobId`, обновляет метаданные только после успешной загрузки blob-а, коммитит изменения и ставит старый blob в очередь на удаление. Это исключает перезапись "на месте" и сохраняет старый blob нетронутым при ошибке загрузки. |
 | `MoveAsync(fileId, targetFolderId)` → `File` | Меняет `FolderId` файла. Проверяет уникальность имени в целевой папке. |
 | `ReorderAsync(fileId, position)` | Устанавливает для файла `SortOrder` в указанную позицию с нуля и переиндексирует всех соседей (файлы и папки) внутри родительской папки. |
-| `UpdateTextContentAsync(fileId, text)` → `File` | Заменяет содержимое текстового файла из строки. Обновляет `sizeBytes`; остальные метаданные не меняются. |
-| `DeleteByFolderAsync(folderId)` | Удаляет все файлы в папке. Используется при рекурсивном удалении папки. |
+| `UpdateTextContentAsync(fileId, text)` → `File` | Заменяет содержимое текстового файла, записывая новый blob под новым `BlobId`, затем обновляет `sizeBytes` и ставит старый blob в очередь на очистку. |
+| `DeleteByFolderAsync(folderId)` | Удаляет все файлы в папке. Используется при рекурсивном удалении папки; очистка blob-ов ставится в очередь после commit. |
 
 **Зависимости**
 
@@ -112,7 +112,9 @@
 | `IFileRepository` | Хранение и чтение метаданных. |
 | `IFolderRepository` | Проверка существования целевой папки при загрузке и перемещении. |
 | `IBlobStorageService` | Хранение и получение бинарного содержимого файлов. |
+| `IBlobDeletionQueue` | Сериализует post-commit удаление blob-ов через hosted background worker. |
 | `ICurrentUserService` | Ограничение по владельцу. |
+| `IUnitOfWork` | Сохраняет изменения метаданных после успешной записи blob-а. |
 
 ---
 
@@ -143,16 +145,16 @@
 
 ### 1.7 IAttachmentService
 
-**Назначение.** Подготавливает загрузки файлов, которые будут использованы в будущем вызове `SendMessage` через хаб. Вложения представляют собой временную staging-зону — они существуют потому, что стандартный лимит сообщения SignalR в 32 КБ делает его непригодным для передачи бинарных данных, поэтому файлы должны сначала приходить через REST, а уже затем упоминаться в сообщении чата по ID.
+**Назначение.** Подготавливает загрузки файлов, которые будут использованы в будущем вызове `SendMessage` через хаб. Вложения представляют собой временную staging-зону — они существуют потому, что стандартный лимит сообщения SignalR в 32 КБ делает его непригодным для передачи бинарных данных, поэтому файлы должны сначала приходить через REST, а уже затем упоминаться в сообщении чата по ID. Каждое вложение получает собственный `BlobId`, а сами загрузки передаются как упорядоченный список пар `(ChatAttachment Attachment, Stream Content)`, чтобы метаданные и поток содержимого не расходились.
 
 **Методы**
 
 | Метод | Описание |
 |---|---|
-| `UploadAsync(attachments, contents)` → `List<ChatAttachment>` | Сохраняет предварительно созданные метаданные вложений с соответствующими потоками содержимого. WebAPI маппит multipart-загрузки в этот контракт. Возвращает ID для дальнейшего использования. |
-| `GetByIdsAsync(attachmentIds)` → `List<ChatAttachment>` | Получает сущности вложений вместе с их storage keys. Используется orchestration-сервисом для построения AI-prompts. Проверяет, что все ID принадлежат текущему пользователю и ещё не были использованы. |
+| `UploadAsync(uploads)` → `IReadOnlyList<ChatAttachment>` | Назначает `BlobId`, сохраняет каждый blob, затем сохраняет коллекцию метаданных вложений. WebAPI маппит multipart-загрузки в этот упорядоченный контракт. |
+| `GetByIdsAsync(attachmentIds)` → `IReadOnlyList<ChatAttachment>` | Получает сущности вложений вместе с их `BlobId`. Используется orchestration-сервисом для построения AI-prompts. Проверяет, что все ID принадлежат текущему пользователю и ещё не были использованы. |
 | `MarkConsumedAsync(attachmentIds)` | Помечает вложения как использованные, чтобы их нельзя было повторно использовать или удалить как просроченные. Вызывается после успешной привязки к сообщению чата. |
-| `PurgeExpiredAsync()` | Удаляет вложения старше 1 часа, которые так и не были использованы. Предназначен для вызова фоновой задачей или hosted service. |
+| `PurgeExpiredAsync()` → `IReadOnlyList<ChatAttachment>` | Удаляет вложения старше 1 часа, которые так и не были использованы, затем ставит blob-ы удалённых записей в очередь на очистку. Предназначен для вызова фоновой задачей или hosted service. |
 
 **Зависимости**
 
@@ -160,6 +162,7 @@
 |---|---|
 | `IAttachmentRepository` | Хранение и чтение метаданных вложений. |
 | `IBlobStorageService` | Хранение бинарного содержимого. |
+| `IBlobDeletionQueue` | Ставит в очередь best-effort удаление blob-ов для просроченных вложений после DB commit. |
 | `ICurrentUserService` | Проверка владельца. |
 | `IUnitOfWork` | Координация сохранения (метаданные + blob). |
 
@@ -425,6 +428,7 @@
 | `DeleteAsync(fileId)` | Удаляет файловую сущность. |
 | `DeleteByFolderAsync(folderId)` | Удаляет все файлы в папке (для рекурсивного удаления папки). |
 | `GetByFolderAsync(folderId)` → `List<File>` | Все файлы в папке (для рекурсивного удаления папки — нужны storage keys для удаления blob-объектов). |
+| `GetExistingBlobIdsAsync(blobIds, cancellationToken)` → `IReadOnlySet<Guid>` | Возвращает, какие candidate blob IDs всё ещё привязаны к файлам. Используется orphan cleanup в batch-режиме с поддержкой отмены. |
 
 ---
 
@@ -481,6 +485,7 @@
 | `MarkConsumedAsync(ids)` | Обновляет статус на consumed. |
 | `GetExpiredUnconsumedAsync(olderThan)` → `List<Attachment>` | Используется purge-задачей. |
 | `DeleteRangeAsync(ids)` | Удаляет записи вложений. |
+| `GetExistingBlobIdsAsync(blobIds, cancellationToken)` → `IReadOnlySet<Guid>` | Возвращает, какие candidate blob IDs всё ещё привязаны к вложениям. Используется orphan cleanup в batch-режиме с поддержкой отмены. |
 
 ---
 
@@ -503,20 +508,29 @@
 
 ### 2.10 IBlobStorageService
 
-**Назначение.** Абстракция хранилища бинарных файлов. Отвязывает приложение от физического механизма хранения (локальная файловая система для MVP, позже облачное blob-хранилище).
+**Назначение.** Абстракция хранилища бинарных файлов. Отвязывает приложение от физического механизма хранения. Текущая реализация основана на `blobId`, не хранит состояние и делегирует работу внутреннему провайдеру (`FileSystem` или `S3`) без staging и без транзакционной координации с базой данных.
 
 | Метод | Описание |
 |---|---|
-| `SaveAsync(content, file)` | Сохраняет бинарное содержимое, используя метаданные из сущности `File`. |
-| `SaveAsync(content, id)` | Сохраняет бинарное содержимое по GUID (используется для вложений и других blob-ов, не привязанных к `File`). |
-| `GetAsync(fileId)` → `Stream` | Получает всё бинарное содержимое по ID файла. |
-| `GetRangeAsync(fileId, rangeStart, rangeEnd)` → `Stream` | Получает диапазон байтов (для поддержки HTTP Range). |
-| `DeleteAsync(fileId)` | Удаляет бинарное содержимое по ID файла. |
-| `GetSizeAsync(fileId)` → `long` | Возвращает размер сохранённого содержимого (для Range/Content-Length). |
+| `SaveAsync(content, blobId)` | Сохраняет бинарное содержимое по `blobId`. Используется и для файлов, и для chat attachments. |
+| `GetAsync(blobId)` → `Stream` | Получает всё бинарное содержимое по `blobId`. |
+| `GetRangeAsync(blobId, rangeStart, rangeEnd)` → `Stream` | Получает диапазон байтов по `blobId`. Общая валидация отклоняет отрицательные и инвертированные диапазоны до вызова провайдера. |
+| `DeleteAsync(blobId)` | Удаляет бинарное содержимое по `blobId`. Используется для eager cleanup и orphan cleanup. |
+| `GetSizeAsync(blobId)` → `long` | Возвращает размер сохранённого содержимого по `blobId` (для Range/Content-Length). |
 
 ---
 
-### 2.11 IEncryptionService
+### 2.11 IBlobDeletionQueue
+
+**Назначение.** Ставит post-commit удаление blob-ов в очередь на одиночный hosted background worker. Это убирает best-effort cleanup из request scope и исключает fire-and-forget работу на scoped-сервисах.
+
+| Метод | Описание |
+|---|---|
+| `EnqueueDeleteAsync(blobId)` | Добавляет `blobId` в bounded-очередь удаления. Реальное удаление выполняет hosted worker через `IBlobStorageService.DeleteAsync`. |
+
+---
+
+### 2.12 IEncryptionService
 
 **Назначение.** Шифрует и расшифровывает чувствительные данные в покое, в частности API keys для LLM.
 
@@ -642,6 +656,7 @@ flowchart LR
         direction TB
         AIService["IAIService"]:::port
         BlobStorage["IBlobStorageService"]:::port
+        BlobDeletionQueue["IBlobDeletionQueue"]:::helper
         Encryption["IEncryptionService"]:::port
         JwtService["IJwtService"]:::port
         PasswordHasher["IPasswordHasher"]:::helper
@@ -652,7 +667,8 @@ flowchart LR
         direction TB
         DB[(PostgreSQL)]:::external
         LLM["LLM-провайдер"]:::external
-        BlobStore["Файловая система или cloud blob storage"]:::external
+        BlobStore["Файловая система или S3-compatible blob storage"]:::external
+        HostedWorkers["Hosted background workers"]:::external
         KeyConfig["Ключи, секреты, конфигурация"]:::external
         SignalR["Контекст SignalR-хаба"]:::external
     end
@@ -669,8 +685,18 @@ flowchart LR
 
     AIService --> LLM
     BlobStorage --> BlobStore
+    BlobDeletionQueue --> HostedWorkers
+    HostedWorkers --> BlobStore
     Encryption --> KeyConfig
     JwtService --> KeyConfig
     PasswordHasher --> KeyConfig
     ChatNotificationPort --> SignalR
 ```
+
+### 3.3 Примечания по runtime blob storage
+
+- `File.BlobId` и `ChatAttachment.BlobId` являются устойчивыми storage keys. Потоки replace и delete намеренно создают orphan blob-ы, а не пытаются координировать blob state внутри DB transaction.
+- `IBlobStorageService`, `IBlobStorageProvider` и `IAmazonS3` зарегистрированы как singleton-safe компоненты. `PostgresUnitOfWork` остаётся scoped, потому что оборачивает `AppDbContext`.
+- Best-effort eager delete выполняется через `IBlobDeletionQueue`, то есть через bounded single-reader background worker, а не через fire-and-forget задачи вида `_ = DeleteAsync(...)`.
+- `BlobOrphanCleanupService` выполняет один cleanup cycle сразу при старте, а затем повторяет его по настроенному интервалу. Очистка обрабатывает candidate blob-ы пакетами, передаёт `CancellationToken` в repository lookups и удаляет только blob-ы старше grace period, которые больше не привязаны к данным.
+- При выборе провайдера `S3` на старте также запускается `S3BucketInitializationService`, который валидирует наличие настроенного bucket-а и создаёт его, если bucket отсутствует.

--- a/docs/agents/SERVICES_ARCHITECTURE.md
+++ b/docs/agents/SERVICES_ARCHITECTURE.md
@@ -87,7 +87,7 @@ These are the primary units of business logic. Each service is defined as an int
 
 ### 1.5 IFileService
 
-**Purpose.** Manages file metadata CRUD, binary upload/download/replace, text content updates, reordering, and file movement between folders. Files carry a `SortOrder` that shares the same ordering space as sibling folders, enabling mixed drag-and-drop interleaving. Validates name uniqueness within a folder, enforces size limits, and delegates binary storage to a blob abstraction.
+**Purpose.** Manages file metadata CRUD, binary upload/download/replace, text content updates, reordering, and file movement between folders. Files carry a `SortOrder` that shares the same ordering space as sibling folders, enabling mixed drag-and-drop interleaving. Validates name uniqueness within a folder, enforces size limits, and delegates binary storage to a blob abstraction. Binary content is addressed by a separate `File.BlobId`, not by the entity ID, so replace/delete flows use orphan cleanup rather than in-place blob mutation.
 
 **Methods**
 
@@ -95,15 +95,15 @@ These are the primary units of business logic. Each service is defined as an int
 |---|---|
 | `GetByIdAsync(fileId)` → `File` | File metadata including owning folder name. |
 | `ListByFolderAsync(folderId, page, pageSize)` → `(List<File> Files, int TotalCount)` | Offset-paginated file listing within a folder. |
-| `UploadAsync(folderId, file, stream)` → `File` | Stores the binary via `IBlobStorageService`, then persists the provided file metadata entity. Validates name uniqueness and size limit. |
-| `UpdateMetadataAsync(fileId, file)` → `File` | Updates mutable file metadata (name/description). Validates name uniqueness within the file's current folder. |
-| `DeleteAsync(fileId)` | Deletes the metadata record and the binary blob. |
+| `UploadAsync(file, stream)` → `File` | Assigns a new `BlobId`, stores the binary via `IBlobStorageService`, then persists the file metadata entity. If DB commit fails, the blob is left orphaned for GC. |
+| `UpdateMetadataAsync(file)` → `File` | Updates mutable file metadata (name/description). Validates name uniqueness within the file's current folder. |
+| `DeleteAsync(fileId)` | Deletes the metadata record, commits that deletion, then enqueues best-effort blob cleanup through `IBlobDeletionQueue`. |
 | `GetContentAsync(fileId, rangeStart?, rangeEnd?)` → `(Stream Content, string ContentType, long SizeBytes)` | Streams the binary content. Returns content type and supports HTTP Range for partial downloads. |
-| `ReplaceContentAsync(fileId, stream, contentType)` → `File` | Replaces the binary blob in place. Metadata (name, description) unchanged; `sizeBytes` and `contentType` updated. |
+| `ReplaceContentAsync(fileId, stream, contentType)` → `File` | Saves the replacement content under a new `BlobId`, updates metadata after blob save succeeds, commits, then enqueues deletion of the old blob. This avoids in-place overwrite and keeps the old blob intact on upload failure. |
 | `MoveAsync(fileId, targetFolderId)` → `File` | Changes the file's `FolderId`. Validates name uniqueness in the target folder. |
 | `ReorderAsync(fileId, position)` | Sets the `SortOrder` of the file to the given 0-based position and re-indexes all siblings (both files and folders) within the parent folder. |
-| `UpdateTextContentAsync(fileId, text)` → `File` | Replaces the content of a text-based file from a plain string. Updates `sizeBytes`; leaves other metadata unchanged. Used by the `PATCH /api/files/{fileId}/content` endpoint. |
-| `DeleteByFolderAsync(folderId)` | Deletes all files in a folder. Used by recursive folder deletion. |
+| `UpdateTextContentAsync(fileId, text)` → `File` | Replaces the content of a text-based file by writing a new blob under a new `BlobId`, then updates `sizeBytes` and queues cleanup for the old blob. |
+| `DeleteByFolderAsync(folderId)` | Deletes all files in a folder. Used by recursive folder deletion; blob cleanup is queued after commit. |
 
 **Dependencies**
 
@@ -112,7 +112,9 @@ These are the primary units of business logic. Each service is defined as an int
 | `IFileRepository` | Metadata persistence. |
 | `IFolderRepository` | Validate target folder existence on upload and move. |
 | `IBlobStorageService` | Store and retrieve binary file content. |
+| `IBlobDeletionQueue` | Serialize best-effort post-commit blob deletes onto a hosted background worker. |
 | `ICurrentUserService` | Ownership scoping. |
+| `IUnitOfWork` | Persist file metadata changes after blob writes succeed. |
 
 ---
 
@@ -143,16 +145,16 @@ These are the primary units of business logic. Each service is defined as an int
 
 ### 1.7 IAttachmentService
 
-**Purpose.** Stages file uploads that will be referenced in a future `SendMessage` hub invocation. Attachments are a temporary holding area — they exist because SignalR's default 32 KB message limit makes it unsuitable for binary payloads, so files must arrive via REST before the chat message references them by ID.
+**Purpose.** Stages file uploads that will be referenced in a future `SendMessage` hub invocation. Attachments are a temporary holding area — they exist because SignalR's default 32 KB message limit makes it unsuitable for binary payloads, so files must arrive via REST before the chat message references them by ID. Each attachment gets its own `BlobId`, and uploads are passed as an ordered composite list of `(ChatAttachment Attachment, Stream Content)` pairs so metadata and content cannot drift apart.
 
 **Methods**
 
 | Method | Description |
 |---|---|
-| `UploadAsync(attachments, contents)` → `List<ChatAttachment>` | Persists pre-built attachment metadata with matching content streams. WebAPI maps multipart uploads into this contract. Returns IDs for later reference. |
-| `GetByIdsAsync(attachmentIds)` → `List<ChatAttachment>` | Retrieves attachment entities with their storage keys. Used by the orchestration service to build the AI prompt. Validates all IDs belong to the current user and are not yet consumed. |
+| `UploadAsync(uploads)` → `IReadOnlyList<ChatAttachment>` | Assigns `BlobId` values, stores each blob, then persists the attachment metadata collection. WebAPI maps multipart uploads into this ordered contract. |
+| `GetByIdsAsync(attachmentIds)` → `IReadOnlyList<ChatAttachment>` | Retrieves attachment entities with their `BlobId` values. Used by the orchestration service to build the AI prompt. Validates all IDs belong to the current user and are not yet consumed. |
 | `MarkConsumedAsync(attachmentIds)` | Marks attachments as consumed so they are no longer eligible for reuse or purging. Called after successful association with a chat message. |
-| `PurgeExpiredAsync()` | Deletes attachments older than 1 hour that were never consumed. Intended to be called by a background job or hosted service. |
+| `PurgeExpiredAsync()` → `IReadOnlyList<ChatAttachment>` | Deletes attachments older than 1 hour that were never consumed, then queues blob cleanup for the removed records. Intended to be called by a background job or hosted service. |
 
 **Dependencies**
 
@@ -160,6 +162,7 @@ These are the primary units of business logic. Each service is defined as an int
 |---|---|
 | `IAttachmentRepository` | Attachment metadata persistence. |
 | `IBlobStorageService` | Binary content storage. |
+| `IBlobDeletionQueue` | Queue best-effort blob deletion for expired attachments after DB commit. |
 | `ICurrentUserService` | Ownership validation. |
 | `IUnitOfWork` | Coordinated persistence (metadata + blob saves). |
 
@@ -425,6 +428,7 @@ These interfaces are defined in `ShuKnow.Application` and implemented in `ShuKno
 | `DeleteAsync(fileId)` | Delete a file entity. |
 | `DeleteByFolderAsync(folderId)` | Delete all files in a folder (for recursive folder delete). |
 | `GetByFolderAsync(folderId)` → `List<File>` | All files in a folder (for recursive folder delete — need storage keys to delete blobs). |
+| `GetExistingBlobIdsAsync(blobIds, cancellationToken)` → `IReadOnlySet<Guid>` | Returns which candidate blob IDs are still referenced by files. Used by orphan cleanup in batched, cancellation-aware scans. |
 
 ---
 
@@ -481,6 +485,7 @@ These interfaces are defined in `ShuKnow.Application` and implemented in `ShuKno
 | `MarkConsumedAsync(ids)` | Update status to consumed. |
 | `GetExpiredUnconsumedAsync(olderThan)` → `List<Attachment>` | For the purge job. |
 | `DeleteRangeAsync(ids)` | Delete attachment records. |
+| `GetExistingBlobIdsAsync(blobIds, cancellationToken)` → `IReadOnlySet<Guid>` | Returns which candidate blob IDs are still referenced by attachments. Used by orphan cleanup in batched, cancellation-aware scans. |
 
 ---
 
@@ -503,20 +508,29 @@ These interfaces are defined in `ShuKnow.Application` and implemented in `ShuKno
 
 ### 2.10 IBlobStorageService
 
-**Purpose.** Binary file storage abstraction. Decouples the application from the physical storage mechanism (local disk for MVP, cloud blob storage later).
+**Purpose.** Binary file storage abstraction. Decouples the application from the physical storage mechanism. The current implementation is blob-ID based, stateless, and delegates to an internal provider (`FileSystem` or `S3`) without staging or transactional coordination with the database.
 
 | Method | Description |
 |---|---|
-| `SaveAsync(content, file)` | Stores the binary content using metadata from the `File` entity. |
-| `SaveAsync(content, id)` | Stores binary content by a raw GUID (used for attachments and other non-`File` blobs). |
-| `GetAsync(fileId)` → `Stream` | Retrieves the full binary content by file ID. |
-| `GetRangeAsync(fileId, rangeStart, rangeEnd)` → `Stream` | Retrieves a byte range (for HTTP Range support). |
-| `DeleteAsync(fileId)` | Removes the binary content by file ID. |
-| `GetSizeAsync(fileId)` → `long` | Returns the stored content size (for Range/Content-Length). |
+| `SaveAsync(content, blobId)` | Stores binary content by blob ID. Used for both files and chat attachments. |
+| `GetAsync(blobId)` → `Stream` | Retrieves the full binary content by blob ID. |
+| `GetRangeAsync(blobId, rangeStart, rangeEnd)` → `Stream` | Retrieves a byte range by blob ID. Shared validation rejects negative or inverted ranges before provider calls. |
+| `DeleteAsync(blobId)` | Removes binary content by blob ID. Used for best-effort eager cleanup and by orphan cleanup workers. |
+| `GetSizeAsync(blobId)` → `long` | Returns the stored content size by blob ID (for Range/Content-Length). |
 
 ---
 
-### 2.11 IEncryptionService
+### 2.11 IBlobDeletionQueue
+
+**Purpose.** Queues post-commit blob deletions onto a single hosted background worker. This keeps best-effort cleanup off request scopes and avoids fire-and-forget work on scoped services.
+
+| Method | Description |
+|---|---|
+| `EnqueueDeleteAsync(blobId)` | Adds a blob ID to the bounded delete queue. The hosted worker performs the actual `IBlobStorageService.DeleteAsync` call. |
+
+---
+
+### 2.12 IEncryptionService
 
 **Purpose.** Encrypts and decrypts sensitive data at rest, specifically LLM API keys.
 
@@ -642,6 +656,7 @@ flowchart LR
         direction TB
         AIService["IAIService"]:::port
         BlobStorage["IBlobStorageService"]:::port
+        BlobDeletionQueue["IBlobDeletionQueue"]:::helper
         Encryption["IEncryptionService"]:::port
         JwtService["IJwtService"]:::port
         PasswordHasher["IPasswordHasher"]:::helper
@@ -652,7 +667,8 @@ flowchart LR
         direction TB
         DB[(PostgreSQL)]:::external
         LLM["LLM provider"]:::external
-        BlobStore["File system or cloud blob store"]:::external
+        BlobStore["File system or S3-compatible blob store"]:::external
+        HostedWorkers["Hosted background workers"]:::external
         KeyConfig["Keys, secrets, configuration"]:::external
         SignalR["SignalR hub context"]:::external
     end
@@ -669,8 +685,18 @@ flowchart LR
 
     AIService --> LLM
     BlobStorage --> BlobStore
+    BlobDeletionQueue --> HostedWorkers
+    HostedWorkers --> BlobStore
     Encryption --> KeyConfig
     JwtService --> KeyConfig
     PasswordHasher --> KeyConfig
     ChatNotificationPort --> SignalR
 ```
+
+### 3.3 Blob storage runtime notes
+
+- `File.BlobId` and `ChatAttachment.BlobId` are the durable storage keys. Replace and delete flows intentionally create orphans rather than mutating or coordinating blob state inside the DB transaction.
+- `IBlobStorageService`, `IBlobStorageProvider`, and `IAmazonS3` are registered as singleton-safe components. `PostgresUnitOfWork` remains scoped because it wraps `AppDbContext`.
+- Best-effort eager deletes run through `IBlobDeletionQueue`, a bounded single-reader background worker, instead of `_ = DeleteAsync(...)` fire-and-forget tasks.
+- `BlobOrphanCleanupService` runs one cleanup cycle immediately on startup and then on the configured interval. Cleanup batches candidate blobs, passes `CancellationToken` into repository lookups, and deletes only blobs older than the grace period that are no longer referenced.
+- When the provider is `S3`, startup also runs `S3BucketInitializationService`, which validates the configured bucket and creates it if it is missing.


### PR DESCRIPTION
Resolves #67 (сикс севен)
Затронуты: #37 (#39 ), #65 

# Что сделано
- Реализован BlobStorageService, который использует FileSystemBlobStorageProvider (блобы через локальные файлы) и S3BlobStorageProvider (для S3-хранилищ)
- Теперь File и Attachment хранят BlobId - айди блоба в хранилище. Это необходимо для атомарности
- Блобы-сироты (orphaned blobs), у которых нет File и Attachment, удаляются раз в некоторое время отдельным воркером (orphan GC) ((сборщик мусора-сирот))
- Написаны unit и integration тесты

# Как обеспечивается согласованность данных
## При добавлении/обновлении файла
- Создаём блоб с новым айди и сохраняем в BlobStorage
- Если успешно, то сохраняем в бд новый айди у блоба данного файла
- Если fail, то ничего не сохраняем и ничего делать не нужно.
- Если fail у бд, то у нас остался orphan блоб, его потом удалит orphan GC

## При удалении файла
- Удаляем запись из бд
- Если успешно, удаляем из BlobStorage
- Если fail, то ничего не делаем, всё ок
- Если fail при удалении, то orphan GC его потом удалит