### PR TITLE
Фикс порядка сообщений [#126]

### DIFF
--- a/backend/ShuKnow.Application.Tests/Services/ChatServiceTests.cs
+++ b/backend/ShuKnow.Application.Tests/Services/ChatServiceTests.cs
@@ -136,6 +136,41 @@ public class ChatServiceTests
     }
 
     [Test]
+    public async Task GetMessagesAsync_WithoutCursor_ShouldReturnSortedMessagesFromRepository()
+    {
+        var session = CreateSession();
+        var messages = new[]
+        {
+            ChatMessage.CreateUserMessage(session.Id, "hello")
+        };
+
+        chatSessionRepository.GetActiveAsync(currentUserId).Returns(Success(session));
+        chatMessageRepository.GetBySessionAsync(session.Id)
+            .Returns(Success<IReadOnlyCollection<ChatMessage>>(messages));
+
+        var result = await sut.GetMessagesAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo(messages);
+        await chatMessageRepository.Received(1).GetBySessionAsync(session.Id);
+    }
+
+    [Test]
+    public async Task GetMessageCountAsync_WhenCalled_ShouldReturnRepositoryCountForActiveSession()
+    {
+        var session = CreateSession();
+
+        chatSessionRepository.GetActiveAsync(currentUserId).Returns(Success(session));
+        chatMessageRepository.CountBySessionAsync(session.Id).Returns(Success(3));
+
+        var result = await sut.GetMessageCountAsync();
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(3);
+        await chatMessageRepository.Received(1).CountBySessionAsync(session.Id);
+    }
+
+    [Test]
     public async Task PersistMessageAsync_WhenSessionDoesNotExist_ShouldReturnNotFound()
     {
         var session = CreateSession();
@@ -171,9 +206,13 @@ public class ChatServiceTests
         chatSessionRepository.AddAsync(Arg.Any<ChatSession>()).Returns(Success());
         chatSessionRepository.DeleteAsync(Arg.Any<Guid>()).Returns(Success());
         chatMessageRepository.AddAsync(Arg.Any<ChatMessage>()).Returns(Success());
+        chatMessageRepository.AddRangeAsync(Arg.Any<IReadOnlyCollection<ChatMessage>>()).Returns(Success());
+        chatMessageRepository.GetBySessionAsync(Arg.Any<Guid>())
+            .Returns(Success<IReadOnlyCollection<ChatMessage>>([]));
         chatMessageRepository.DeleteBySessionAsync(Arg.Any<Guid>()).Returns(Success());
         chatMessageRepository.GetPageAsync(Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<int>())
             .Returns(Success<(IReadOnlyList<ChatMessage> Messages, string? NextCursor)>(([], null)));
+        chatMessageRepository.CountBySessionAsync(Arg.Any<Guid>()).Returns(Success(0));
     }
 
     private ChatSession CreateSession(Guid? sessionId = null)

--- a/backend/ShuKnow.Application/Interfaces/IChatService.cs
+++ b/backend/ShuKnow.Application/Interfaces/IChatService.cs
@@ -16,6 +16,8 @@ public interface IChatService
     
     Task<Result<IReadOnlyCollection<ChatMessage>>> GetMessagesAsync(CancellationToken ct = default);
 
+    Task<Result<int>> GetMessageCountAsync(CancellationToken ct = default);
+
     Task<Result<ChatMessage>> PersistMessageAsync(ChatMessage message, CancellationToken ct = default);
     
     Task<Result> PersistMessagesAsync(

--- a/backend/ShuKnow.Application/Services/ChatService.cs
+++ b/backend/ShuKnow.Application/Services/ChatService.cs
@@ -49,7 +49,13 @@ public class ChatService(
     public async Task<Result<IReadOnlyCollection<ChatMessage>>> GetMessagesAsync(CancellationToken ct = default)
     {
         return await GetOrCreateActiveSessionAsync(ct)
-            .MapAsync(session => session.Messages);
+            .BindAsync(session => chatMessageRepository.GetBySessionAsync(session.Id));
+    }
+
+    public async Task<Result<int>> GetMessageCountAsync(CancellationToken ct = default)
+    {
+        return await GetOrCreateActiveSessionAsync(ct)
+            .BindAsync(session => chatMessageRepository.CountBySessionAsync(session.Id));
     }
 
     public async Task<Result<ChatMessage>> PersistMessageAsync(ChatMessage message, CancellationToken ct = default)

--- a/backend/ShuKnow.Domain/Entities/ChatMessage.cs
+++ b/backend/ShuKnow.Domain/Entities/ChatMessage.cs
@@ -9,48 +9,57 @@ public class ChatMessage : IEntity<Guid>
     public Guid SessionId { get; private set; }
     public ChatMessageRole Role { get; private set; }
     public string Content { get; private set; } = string.Empty;
-    public int? Index { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
 
     protected ChatMessage()
     {
     }
 
-    private ChatMessage(Guid chatMessageId, Guid sessionId, ChatMessageRole role, string content, int? index = null)
+    private ChatMessage(
+        Guid chatMessageId,
+        Guid sessionId,
+        ChatMessageRole role,
+        string content,
+        DateTimeOffset? createdAt = null)
     {
         Id = chatMessageId;
         SessionId = sessionId;
         Role = role;
         Content = content;
-        Index = index;
+        CreatedAt = createdAt ?? DateTimeOffset.UtcNow;
     }
 
-    public static ChatMessage CreateUserMessage(Guid sessionId, string content, int? index = null)
+    public static ChatMessage CreateUserMessage(Guid sessionId, string content, DateTimeOffset? createdAt = null)
     {
         return new ChatMessage(
             chatMessageId: Guid.NewGuid(),
             sessionId: sessionId,
             role: ChatMessageRole.User,
             content: content,
-            index: index);
+            createdAt: createdAt);
     }
 
-    public static ChatMessage CreateAiMessage(Guid messageId, Guid sessionId, string content, int? index = null)
+    public static ChatMessage CreateAiMessage(
+        Guid messageId,
+        Guid sessionId,
+        string content,
+        DateTimeOffset? createdAt = null)
     {
         return new ChatMessage(
             chatMessageId: messageId,
             sessionId: sessionId,
             role: ChatMessageRole.Ai,
             content: content,
-            index: index);
+            createdAt: createdAt);
     }
 
-    public static ChatMessage CreateSystemMessage(Guid sessionId, string content, int? index = null)
+    public static ChatMessage CreateSystemMessage(Guid sessionId, string content, DateTimeOffset? createdAt = null)
     {
         return new ChatMessage(
             chatMessageId: Guid.NewGuid(),
             sessionId: sessionId,
             role: ChatMessageRole.System,
             content: content,
-            index: index);
+            createdAt: createdAt);
     }
 }

--- a/backend/ShuKnow.Domain/Entities/ChatSession.cs
+++ b/backend/ShuKnow.Domain/Entities/ChatSession.cs
@@ -9,8 +9,6 @@ public class ChatSession : IEntity<Guid>
 
     public Guid UserId { get; private set; }
     public ChatSessionStatus Status { get; private set; } = ChatSessionStatus.Active;
-    
-    public virtual IReadOnlyCollection<ChatMessage> Messages { get; private set; } = new List<ChatMessage>();
 
     protected ChatSession()
     {

--- a/backend/ShuKnow.Domain/Repositories/IChatMessageRepository.cs
+++ b/backend/ShuKnow.Domain/Repositories/IChatMessageRepository.cs
@@ -9,10 +9,14 @@ public interface IChatMessageRepository
     
     Task<Result> AddRangeAsync(IReadOnlyCollection<ChatMessage> messages);
 
+    Task<Result<IReadOnlyCollection<ChatMessage>>> GetBySessionAsync(Guid sessionId);
+
     Task<Result<(IReadOnlyList<ChatMessage> Messages, string? NextCursor)>> GetPageAsync(
         Guid sessionId,
         string? cursor,
         int limit);
+
+    Task<Result<int>> CountBySessionAsync(Guid sessionId);
 
     Task<Result> DeleteBySessionAsync(Guid sessionId);
 }

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/ChatMessageRepositoryTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/ChatMessageRepositoryTests.cs
@@ -17,12 +17,20 @@ public class ChatMessageRepositoryTests : BaseRepositoryTests
     }
 
     [Test]
-    public async Task WithMixedNullAndNonNullIndexes_ShouldReturnCorrectOrderAndPages()
+    public async Task WithMixedCreatedAtValues_ShouldReturnCorrectOrderAndPages()
     {
         var user = await SeedUserAsync();
         var session = await SeedSessionAsync(user.Id);
+        var start = new DateTimeOffset(2026, 04, 01, 12, 00, 00, TimeSpan.Zero);
 
-        await SeedMessagesAsync(session.Id, null, null, 1, 2, null, 3);
+        await SeedMessagesAsync(
+            session.Id,
+            start,
+            start.AddMinutes(3),
+            start.AddMinutes(1),
+            start.AddMinutes(4),
+            start.AddMinutes(2),
+            start.AddMinutes(5));
         
         var expectedOrder = await GetExpectedOrderAsync(session.Id);
 
@@ -38,12 +46,13 @@ public class ChatMessageRepositoryTests : BaseRepositoryTests
     }
 
     [Test]
-    public async Task WithDuplicateIndexes_ShouldUseIdAsTieBreaker()
+    public async Task WithDuplicateCreatedAtValues_ShouldUseIdAsTieBreaker()
     {
         var user = await SeedUserAsync();
         var session = await SeedSessionAsync(user.Id);
+        var createdAt = new DateTimeOffset(2026, 04, 01, 12, 00, 00, TimeSpan.Zero);
 
-        await SeedMessagesAsync(session.Id, 5, 5, 5, 5, 5);
+        await SeedMessagesAsync(session.Id, createdAt, createdAt, createdAt, createdAt, createdAt);
         
         var expectedOrder = await GetExpectedOrderAsync(session.Id);
 
@@ -63,8 +72,14 @@ public class ChatMessageRepositoryTests : BaseRepositoryTests
     {
         var user = await SeedUserAsync();
         var session = await SeedSessionAsync(user.Id);
+        var start = new DateTimeOffset(2026, 04, 01, 12, 00, 00, TimeSpan.Zero);
 
-        await SeedMessagesAsync(session.Id, null, 1, 1, 2);
+        await SeedMessagesAsync(
+            session.Id,
+            start,
+            start.AddMinutes(1),
+            start.AddMinutes(1),
+            start.AddMinutes(2));
         var expectedOrder = await GetExpectedOrderAsync(session.Id);
 
         var page1 = await sut.GetPageAsync(session.Id, null, 2);
@@ -87,7 +102,10 @@ public class ChatMessageRepositoryTests : BaseRepositoryTests
         var user2 = await SeedUserAsync();
         var session2 = await SeedSessionAsync(user2.Id);
 
-        await SeedMessagesAsync(session1.Id, 1, 2);
+        await SeedMessagesAsync(
+            session1.Id,
+            new DateTimeOffset(2026, 04, 01, 12, 00, 00, TimeSpan.Zero),
+            new DateTimeOffset(2026, 04, 01, 12, 01, 00, TimeSpan.Zero));
         var s1Page = await sut.GetPageAsync(session1.Id, null, 1);
         
         var foreignCursor = s1Page.Value.NextCursor;
@@ -126,12 +144,12 @@ public class ChatMessageRepositoryTests : BaseRepositoryTests
         return session;
     }
 
-    private async Task SeedMessagesAsync(Guid sessionId, params int?[] indexes)
+    private async Task SeedMessagesAsync(Guid sessionId, params DateTimeOffset[] createdAtValues)
     {
         await using var seedContext = CreateDbContext();
-        foreach (var index in indexes)
+        foreach (var createdAt in createdAtValues)
         {
-            var msg = ChatMessage.CreateUserMessage(sessionId, $"Message {index}", index);
+            var msg = ChatMessage.CreateUserMessage(sessionId, $"Message {createdAt:O}", createdAt);
             seedContext.ChatMessages.Add(msg);
         }
         await seedContext.SaveChangesAsync();
@@ -142,7 +160,7 @@ public class ChatMessageRepositoryTests : BaseRepositoryTests
         await using var ctx = CreateDbContext();
         return await ctx.ChatMessages
             .Where(m => m.SessionId == sessionId)
-            .OrderBy(m => m.Index)
+            .OrderBy(m => m.CreatedAt)
             .ThenBy(m => m.Id)
             .ToListAsync();
     }

--- a/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/ChatSessionRepositoryTests.cs
+++ b/backend/ShuKnow.Infrastructure.IntegrationTests/Persistent/Repositories/ChatSessionRepositoryTests.cs
@@ -34,27 +34,6 @@ public class ChatSessionRepositoryTests : BaseRepositoryTests
     }
 
     [Test]
-    public async Task GetActiveAsync_ShouldIncludeOrderedMessages()
-    {
-        var user = await SeedUserAsync();
-        var session = await SeedSessionAsync(user.Id);
-        var laterMessage = ChatMessage.CreateUserMessage(session.Id, "later", index: 2);
-        var earlierMessage = ChatMessage.CreateSystemMessage(session.Id, "earlier", index: 1);
-
-        await using (var seedContext = CreateDbContext())
-        {
-            seedContext.ChatMessages.AddRange(laterMessage, earlierMessage);
-            await seedContext.SaveChangesAsync();
-        }
-
-        var result = await sut.GetActiveAsync(user.Id);
-
-        result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Messages.Should().NotBeNull();
-        result.Value.Messages.Select(message => message.Content).Should().Equal("earlier", "later");
-    }
-
-    [Test]
     public async Task GetActiveAsync_WhenOnlyClosedSessionExists_ShouldReturnNotFound()
     {
         var user = await SeedUserAsync();

--- a/backend/ShuKnow.Infrastructure.Tests/Services/TornadoAiServiceTests.cs
+++ b/backend/ShuKnow.Infrastructure.Tests/Services/TornadoAiServiceTests.cs
@@ -150,6 +150,33 @@ public class TornadoAiServiceTests
     }
 
     [Test]
+    public async Task ProcessMessageAsync_WhenUserMessagePersistenceFails_ShouldReturnFailure()
+    {
+        chatService.PersistMessageAsync(Arg.Any<ChatMessage>(), Arg.Any<CancellationToken>())
+            .Returns(Error<ChatMessage>("persist failed"));
+
+        var result = await sut.ProcessMessageAsync("hello", attachmentIds: null, settings: settings, operationId: operationId);
+
+        result.Status.Should().Be(ResultStatus.Error);
+        result.Errors.Should().ContainSingle().Which.Should().Be("persist failed");
+    }
+
+    [Test]
+    public async Task ProcessMessageAsync_WhenUserMessagePersistenceFails_ShouldNotStartStreamingResponse()
+    {
+        chatService.PersistMessageAsync(Arg.Any<ChatMessage>(), Arg.Any<CancellationToken>())
+            .Returns(Error<ChatMessage>("persist failed"));
+
+        await sut.ProcessMessageAsync("hello", attachmentIds: null, settings: settings, operationId: operationId);
+
+        await conversation.DidNotReceive()
+            .StreamResponseWithToolsAsync(
+                Arg.Any<Func<List<FunctionCall>, CancellationToken, ValueTask>>(),
+                Arg.Any<Func<string, ValueTask>>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task ProcessMessageAsync_ShouldCreateConversationWithCorrectSettings()
     {
         UserAiSettings? capturedSettings = null;
@@ -268,6 +295,19 @@ public class TornadoAiServiceTests
     }
 
     [Test]
+    public async Task ProcessMessageAsync_ShouldNotDuplicateCurrentUserMessageInPreviousHistory()
+    {
+        var previousMessage = ChatMessage.CreateSystemMessage(session.Id, "existing instruction");
+        chatService.GetMessagesAsync(Arg.Any<CancellationToken>())
+            .Returns(Success<IReadOnlyCollection<ChatMessage>>([previousMessage]));
+
+        await sut.ProcessMessageAsync("hello", attachmentIds: null, settings: settings, operationId: operationId);
+
+        conversation.Received(1).AddMessages(Arg.Is<IEnumerable<TornadoChatMessage>>(messages =>
+            messages.Select(message => message.Content).SequenceEqual(new[] { previousMessage.Content })));
+    }
+
+    [Test]
     public async Task ProcessMessageAsync_WhenNoPreviousMessages_ShouldAddEmptyList()
     {
         chatService.GetMessagesAsync(Arg.Any<CancellationToken>())
@@ -308,6 +348,23 @@ public class TornadoAiServiceTests
                 m.Role == ChatMessageRole.User &&
                 m.Content == prompt),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProcessMessageAsync_WhenSuccessful_ShouldPersistUserMessageBeforeStreamingResponse()
+    {
+        await sut.ProcessMessageAsync("hello", attachmentIds: null, settings: settings, operationId: operationId);
+
+        Received.InOrder(() =>
+        {
+            chatService.PersistMessageAsync(
+                Arg.Is<ChatMessage>(message => message.Role == ChatMessageRole.User && message.Content == "hello"),
+                Arg.Any<CancellationToken>());
+            conversation.StreamResponseWithToolsAsync(
+                Arg.Any<Func<List<FunctionCall>, CancellationToken, ValueTask>>(),
+                Arg.Any<Func<string, ValueTask>>(),
+                Arg.Any<CancellationToken>());
+        });
     }
 
     [Test]
@@ -628,7 +685,7 @@ public class TornadoAiServiceTests
     }
 
     [Test]
-    public async Task ProcessMessageAsync_WhenConversationDoesNotConverge_ShouldNotPersistMessages()
+    public async Task ProcessMessageAsync_WhenConversationDoesNotConverge_ShouldNotPersistAiMessages()
     {
         conversation.StreamResponseWithToolsAsync(
                 Arg.Any<Func<List<FunctionCall>, CancellationToken, ValueTask>>(),
@@ -638,8 +695,6 @@ public class TornadoAiServiceTests
 
         await sut.ProcessMessageAsync("hello", attachmentIds: null, settings: settings, operationId: operationId);
 
-        await chatService.DidNotReceive()
-            .PersistMessageAsync(Arg.Any<ChatMessage>(), Arg.Any<CancellationToken>());
         await chatService.DidNotReceive()
             .PersistMessagesAsync(Arg.Any<IReadOnlyCollection<ChatMessage>>(), Arg.Any<CancellationToken>());
     }

--- a/backend/ShuKnow.Infrastructure/Migrations/20260422103000_UseCreatedAtForChatMessageOrdering.Designer.cs
+++ b/backend/ShuKnow.Infrastructure/Migrations/20260422103000_UseCreatedAtForChatMessageOrdering.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ShuKnow.Infrastructure.Persistent;
@@ -11,9 +12,10 @@ using ShuKnow.Infrastructure.Persistent;
 namespace ShuKnow.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422103000_UseCreatedAtForChatMessageOrdering")]
+    partial class UseCreatedAtForChatMessageOrdering
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -221,8 +223,7 @@ namespace ShuKnow.Infrastructure.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
+                        .HasColumnType("text")
                         .HasColumnName("name");
 
                     b.Property<Guid?>("ParentFolderId")
@@ -273,6 +274,7 @@ namespace ShuKnow.Infrastructure.Migrations
             modelBuilder.Entity("ShuKnow.Domain.Entities.UserAiSettings", b =>
                 {
                     b.Property<Guid>("UserId")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("uuid")
                         .HasColumnName("user_id");
 

--- a/backend/ShuKnow.Infrastructure/Migrations/20260422103000_UseCreatedAtForChatMessageOrdering.cs
+++ b/backend/ShuKnow.Infrastructure/Migrations/20260422103000_UseCreatedAtForChatMessageOrdering.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShuKnow.Infrastructure.Migrations
+{
+    public partial class UseCreatedAtForChatMessageOrdering : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_chat_messages_session_id_index_id",
+                table: "chat_messages");
+
+            migrationBuilder.DropColumn(
+                name: "index",
+                table: "chat_messages");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "created_at",
+                table: "chat_messages",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chat_messages_session_id_created_at_id",
+                table: "chat_messages",
+                columns: new[] { "session_id", "created_at", "id" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_chat_messages_session_id_created_at_id",
+                table: "chat_messages");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "chat_messages");
+
+            migrationBuilder.AddColumn<int>(
+                name: "index",
+                table: "chat_messages",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chat_messages_session_id_index_id",
+                table: "chat_messages",
+                columns: new[] { "session_id", "index", "id" });
+        }
+    }
+}

--- a/backend/ShuKnow.Infrastructure/Persistent/DbConfiguration/ChatMessageConfiguration.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/DbConfiguration/ChatMessageConfiguration.cs
@@ -11,9 +11,18 @@ internal class ChatMessageConfiguration : IEntityTypeConfiguration<ChatMessage>
         builder.ToTable("chat_messages");
         builder.HasKey(m => m.Id);
 
+        builder.Property(m => m.CreatedAt)
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
         builder.Property(m => m.Role)
             .HasConversion<int>();
 
-        builder.HasIndex(m => new { m.SessionId, m.Index, m.Id });
+        builder.HasIndex(m => new { m.SessionId, m.CreatedAt, m.Id });
+
+        builder.HasOne<ChatSession>()
+            .WithMany()
+            .HasForeignKey(message => message.SessionId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/DbConfiguration/ChatSessionConfiguration.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/DbConfiguration/ChatSessionConfiguration.cs
@@ -22,10 +22,5 @@ internal class ChatSessionConfiguration : IEntityTypeConfiguration<ChatSession>
             .WithMany()
             .HasForeignKey(session => session.UserId)
             .OnDelete(DeleteBehavior.Cascade);
-
-        builder.HasMany(session => session.Messages)
-            .WithOne()
-            .HasForeignKey(message => message.SessionId)
-            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatMessageRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatMessageRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Ardalis.Result;
 using Microsoft.EntityFrameworkCore;
@@ -22,8 +23,7 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
 
     public async Task<Result<IReadOnlyCollection<ChatMessage>>> GetBySessionAsync(Guid sessionId)
     {
-        var messages = await GetOrderedSessionMessagesQuery(sessionId).ToListAsync();
-        return Result.Success<IReadOnlyCollection<ChatMessage>>(messages.AsReadOnly());
+        return await GetOrderedSessionMessagesQuery(sessionId).ToListAsync();
     }
 
     public async Task<Result<(IReadOnlyList<ChatMessage> Messages, string? NextCursor)>> GetPageAsync(
@@ -83,7 +83,7 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
         if (parts.Length != 3) return false;
 
         if (!Guid.TryParse(parts[0], out var sessionId) || sessionId != expectedSessionId) return false;
-        if (!DateTimeOffset.TryParse(parts[1], null, System.Globalization.DateTimeStyles.RoundtripKind, out var createdAt))
+        if (!DateTimeOffset.TryParse(parts[1], null, DateTimeStyles.RoundtripKind, out var createdAt))
             return false;
 
         if (!Guid.TryParse(parts[2], out var id)) return false;

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatMessageRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatMessageRepository.cs
@@ -20,6 +20,12 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
         return Task.FromResult(Result.Success());
     }
 
+    public async Task<Result<IReadOnlyCollection<ChatMessage>>> GetBySessionAsync(Guid sessionId)
+    {
+        var messages = await GetOrderedSessionMessagesQuery(sessionId).ToListAsync();
+        return Result.Success<IReadOnlyCollection<ChatMessage>>(messages.AsReadOnly());
+    }
+
     public async Task<Result<(IReadOnlyList<ChatMessage> Messages, string? NextCursor)>> GetPageAsync(
         Guid sessionId,
         string? cursor,
@@ -32,18 +38,9 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
             if (!TryParseCursor(cursor, sessionId, out var cursorData))
                 return Result.Invalid(new ValidationError("Invalid or tampered cursor provided."));
 
-            if (cursorData.Index.HasValue)
-            {
-                query = query.Where(m =>
-                    m.Index > cursorData.Index ||
-                    m.Index == null ||
-                    (m.Index == cursorData.Index && m.Id.CompareTo(cursorData.Id) > 0));
-            }
-            else
-            {
-                query = query.Where(m =>
-                    m.Index == null && m.Id.CompareTo(cursorData.Id) > 0);
-            }
+            query = query.Where(m =>
+                m.CreatedAt > cursorData.CreatedAt ||
+                (m.CreatedAt == cursorData.CreatedAt && m.Id.CompareTo(cursorData.Id) > 0));
         }
 
         var messages = await query.Take(limit + 1).ToListAsync();
@@ -60,11 +57,17 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
         return Result.Success();
     }
 
+    public async Task<Result<int>> CountBySessionAsync(Guid sessionId)
+    {
+        var count = await context.ChatMessages.CountAsync(message => message.SessionId == sessionId);
+        return Result.Success(count);
+    }
+
     private IQueryable<ChatMessage> GetOrderedSessionMessagesQuery(Guid sessionId) =>
         context.ChatMessages
             .AsNoTracking()
             .Where(m => m.SessionId == sessionId)
-            .OrderBy(m => m.Index)
+            .OrderBy(m => m.CreatedAt)
             .ThenBy(m => m.Id);
 
     private static bool TryParseCursor(string encodedCursor, Guid expectedSessionId, out CursorData cursorData)
@@ -80,23 +83,18 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
         if (parts.Length != 3) return false;
 
         if (!Guid.TryParse(parts[0], out var sessionId) || sessionId != expectedSessionId) return false;
-
-        int? index = null;
-        if (!string.IsNullOrEmpty(parts[1]))
-        {
-            if (!int.TryParse(parts[1], out var parsedIndex)) return false;
-            index = parsedIndex;
-        }
+        if (!DateTimeOffset.TryParse(parts[1], null, System.Globalization.DateTimeStyles.RoundtripKind, out var createdAt))
+            return false;
 
         if (!Guid.TryParse(parts[2], out var id)) return false;
 
-        cursorData = new CursorData(index, id);
+        cursorData = new CursorData(createdAt, id);
         return true;
     }
 
     private static string EncodeCursor(ChatMessage message)
     {
-        var str = $"{message.SessionId:N}|{message.Index}|{message.Id:N}";
+        var str = $"{message.SessionId:N}|{message.CreatedAt:O}|{message.Id:N}";
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(str));
     }
 
@@ -105,5 +103,5 @@ public class ChatMessageRepository(AppDbContext context) : IChatMessageRepositor
             ? (messages.GetRange(0, limit).AsReadOnly(), EncodeCursor(messages[limit - 1]))
             : (messages.AsReadOnly(), null);
 
-    private readonly record struct CursorData(int? Index, Guid Id);
+    private readonly record struct CursorData(DateTimeOffset CreatedAt, Guid Id);
 }

--- a/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatSessionRepository.cs
+++ b/backend/ShuKnow.Infrastructure/Persistent/Repositories/ChatSessionRepository.cs
@@ -12,7 +12,6 @@ public class ChatSessionRepository(AppDbContext context) : IChatSessionRepositor
     {
         var session = await context.ChatSessions
             .AsNoTracking()
-            .Include(session => session.Messages.OrderBy(message => message.Index).ThenBy(message => message.Id))
             .SingleOrDefaultAsync(session => session.UserId == userId && session.Status == ChatSessionStatus.Active);
 
         return session is null ? Result.NotFound() : Result.Success(session);

--- a/backend/ShuKnow.Infrastructure/Services/TornadoAiService.cs
+++ b/backend/ShuKnow.Infrastructure/Services/TornadoAiService.cs
@@ -6,6 +6,7 @@ using ShuKnow.Application.Common;
 using ShuKnow.Application.Interfaces;
 using ShuKnow.Application.Models.Notifications;
 using ShuKnow.Domain.Entities;
+using ShuKnow.Infrastructure.Extensions;
 using ShuKnow.Infrastructure.Misc;
 using static ShuKnow.Application.Extensions.ResultExtensions;
 using ChatMessage = ShuKnow.Domain.Entities.ChatMessage;
@@ -30,14 +31,24 @@ public class TornadoAiService(
         UserAiSettings settings, Guid operationId, CancellationToken ct = default)
     {
         return await chatService.GetOrCreateActiveSessionAsync(ct)
-            .BindAsync(session => conversationFactory.CreateConversation(settings, toolsService.Tools, temperature)
-                .ActAsync(conversation => PrepareConversation(conversation, content, attachmentIds, ct))
-                .BindAsync(conversation => RunWithTools(conversation, session.Id, operationId, ct))
-                .ActAsync(_ => attachmentIds is null or { Count: 0 }
-                    ? Task.FromResult(Result.Success())
-                    : attachmentService.MarkConsumedAsync(attachmentIds, ct))
-                .ActAsync(_ => chatService.PersistMessageAsync(ChatMessage.CreateUserMessage(session.Id, content), ct))
-                .ActAsync(messages => chatService.PersistMessagesAsync(messages, ct))
+            .BindAsync(session => chatService.GetMessagesAsync(ct)
+                .Map(previousMessages => new ConversationContext(
+                    session,
+                    previousMessages,
+                    ChatMessage.CreateUserMessage(session.Id, content))))
+            .BindAsync(context => conversationFactory.CreateConversation(settings, toolsService.Tools, temperature)
+                .ActAsync(_ => chatService.PersistMessageAsync(context.UserMessage, ct))
+                .ActAsync(conversation => PrepareConversation(
+                    conversation,
+                    context.PreviousMessages,
+                    context.UserMessage.Content,
+                    attachmentIds,
+                    ct))
+                .BindAsync(conversation => RunWithTools(conversation, context.Session.Id, operationId, ct)
+                    .ActAsync(_ => attachmentIds is null or { Count: 0 }
+                        ? Task.FromResult(Result.Success())
+                        : attachmentService.MarkConsumedAsync(attachmentIds, ct))
+                    .ActAsync(messages => chatService.PersistMessagesAsync(messages, ct)))
             )
             .BindAsync(_ => Result.Success());
     }
@@ -54,13 +65,14 @@ public class TornadoAiService(
         return settings;
     }
 
-    private async Task<Result> PrepareConversation<T>(T conversation, string content,
+    private async Task<Result> PrepareConversation<T>(T conversation,
+        IReadOnlyCollection<ChatMessage> previousMessages,
+        string content,
         IReadOnlyCollection<Guid>? attachmentIds, CancellationToken ct = default) where T : ITornadoConversation
     {
         return await promptBuilder.CreateSystemInstructions(ct)
             .Act(conversation.PrependSystemMessage)
-            .BindAsync(_ => promptBuilder.GetPreviousMessages(ct))
-            .Act(conversation.AddMessages)
+            .Act(_ => conversation.AddMessages(previousMessages.Select(message => message.MapToChatMessagePart())))
             .BindAsync(_ => promptBuilder.CreateUserMessages(content, attachmentIds, ct))
             .Act(conversation.AddUserMessage)
             .BindAsync(_ => Result.Success());
@@ -123,4 +135,9 @@ public class TornadoAiService(
         logger.LogError(response.Exception, "Error while processing message with Tornado API");
         return Result.Error("Error while processing message");
     }
+
+    private sealed record ConversationContext(
+        ChatSession Session,
+        IReadOnlyCollection<ChatMessage> PreviousMessages,
+        ChatMessage UserMessage);
 }

--- a/backend/ShuKnow.WebAPI.Tests/Controllers/ChatControllerTests.cs
+++ b/backend/ShuKnow.WebAPI.Tests/Controllers/ChatControllerTests.cs
@@ -43,6 +43,25 @@ public class ChatControllerTests
     }
 
     [Test]
+    public async Task GetChatSession_WhenActiveSessionExists_ShouldReturnDtoWithRepositoryBackedMessageCount()
+    {
+        var session = new ChatSession(Guid.NewGuid(), currentUserId);
+        chatService.GetOrCreateActiveSessionAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success(session)));
+        chatService.GetMessageCountAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success(4)));
+
+        var response = await sut.GetChatSession(CancellationToken.None);
+
+        var objectResult = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status200OK);
+        var dto = objectResult.Value.Should().BeOfType<ChatSessionDto>().Subject;
+        dto.Id.Should().Be(session.Id);
+        dto.MessageCount.Should().Be(4);
+        dto.CanRollback.Should().BeFalse();
+    }
+
+    [Test]
     public async Task UploadChatAttachments_WhenFilesProvided_ShouldPersistAttachmentsAndReturnDtos()
     {
         var formFiles = new FormFileCollection

--- a/backend/ShuKnow.WebAPI.Tests/Mappers/ModelToDtoMappersTests.cs
+++ b/backend/ShuKnow.WebAPI.Tests/Mappers/ModelToDtoMappersTests.cs
@@ -45,26 +45,26 @@ public class ModelToDtoMappersTests
     }
 
     [Test]
-    public void ToDto_WhenChatSessionHasMessages_ShouldMapMessageCount()
+    public void ToDto_WhenChatSessionMapped_ShouldMapProvidedMessageCount()
     {
         var session = new ChatSession(Guid.NewGuid(), Guid.NewGuid());
-        var messages = new[]
-        {
-            ChatMessage.CreateUserMessage(session.Id, "Hello"),
-            ChatMessage.CreateAiMessage(Guid.NewGuid(), session.Id, "Hi")
-        };
-        SetMessages(session, messages);
 
-        var dto = session.ToDto();
+        var dto = session.ToDto(messageCount: 2);
 
-        dto.MessageCount.Should().Be(messages.Length);
+        dto.MessageCount.Should().Be(2);
         dto.CanRollback.Should().BeFalse();
     }
 
-    private static void SetMessages(ChatSession session, IReadOnlyCollection<ChatMessage> messages)
+    [Test]
+    public void ToDto_WhenChatMessageMapped_ShouldUseCreatedAtInsteadOfIndex()
     {
-        typeof(ChatSession)
-            .GetProperty(nameof(ChatSession.Messages))!
-            .SetValue(session, messages);
+        var createdAt = new DateTimeOffset(2026, 04, 01, 12, 00, 00, TimeSpan.Zero);
+        var message = ChatMessage.CreateUserMessage(Guid.NewGuid(), "Hello", createdAt);
+
+        var dto = message.ToDto();
+
+        dto.Id.Should().Be(message.Id);
+        dto.Content.Should().Be("Hello");
+        dto.CreatedAt.Should().Be(createdAt);
     }
 }

--- a/backend/ShuKnow.WebAPI/Controllers/ChatController.cs
+++ b/backend/ShuKnow.WebAPI/Controllers/ChatController.cs
@@ -24,15 +24,9 @@ public class ChatController(
     [HttpGet("session")]
     public async Task<ActionResult<ChatSessionDto>> GetChatSession(CancellationToken ct)
     {
-        var sessionResult = await chatService.GetOrCreateActiveSessionAsync(ct);
-        if (!sessionResult.IsSuccess)
-            return sessionResult
-                .Map(_ => new ChatSessionDto(Guid.Empty, default, 0, false))
-                .ToActionResult(this);
-
-        var countResult = await chatService.GetMessageCountAsync(ct);
-        return countResult
-            .Map(count => sessionResult.Value.ToDto(count))
+        return (await chatService.GetOrCreateActiveSessionAsync(ct)
+            .BindAsync(session => chatService.GetMessageCountAsync(ct)
+                .MapAsync(session.ToDto)))
             .ToActionResult(this);
     }
 

--- a/backend/ShuKnow.WebAPI/Controllers/ChatController.cs
+++ b/backend/ShuKnow.WebAPI/Controllers/ChatController.cs
@@ -24,8 +24,15 @@ public class ChatController(
     [HttpGet("session")]
     public async Task<ActionResult<ChatSessionDto>> GetChatSession(CancellationToken ct)
     {
-        return (await chatService.GetOrCreateActiveSessionAsync(ct))
-            .Map(session => session.ToDto())
+        var sessionResult = await chatService.GetOrCreateActiveSessionAsync(ct);
+        if (!sessionResult.IsSuccess)
+            return sessionResult
+                .Map(_ => new ChatSessionDto(Guid.Empty, default, 0, false))
+                .ToActionResult(this);
+
+        var countResult = await chatService.GetMessageCountAsync(ct);
+        return countResult
+            .Map(count => sessionResult.Value.ToDto(count))
             .ToActionResult(this);
     }
 

--- a/backend/ShuKnow.WebAPI/Dto/Chat/ChatMessageDto.cs
+++ b/backend/ShuKnow.WebAPI/Dto/Chat/ChatMessageDto.cs
@@ -6,5 +6,5 @@ public record ChatMessageDto(
     Guid Id,
     ChatMessageRole Role,
     string Content,
-    int? Index,
+    DateTimeOffset CreatedAt,
     IReadOnlyList<AttachmentDto>? Attachments);

--- a/backend/ShuKnow.WebAPI/Mappers/ModelToDtoMappers.cs
+++ b/backend/ShuKnow.WebAPI/Mappers/ModelToDtoMappers.cs
@@ -18,12 +18,12 @@ public static class ModelToDtoMappers
         return new UserDto(user.Id, user.Login);
     }
 
-    public static ChatSessionDto ToDto(this ChatSession session)
+    public static ChatSessionDto ToDto(this ChatSession session, int messageCount)
     {
         return new ChatSessionDto(
             session.Id,
             (ApiChatSessionStatus)session.Status,
-            session.Messages?.Count ?? 0,
+            messageCount,
             false);
     }
 
@@ -33,7 +33,7 @@ public static class ModelToDtoMappers
             message.Id,
             (ApiChatMessageRole)message.Role,
             message.Content,
-            message.Index,
+            message.CreatedAt,
             null);
     }
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -20,7 +20,11 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_started
-
+  
+  postgres:
+    ports:
+      - "127.0.0.1:54322:5432"
+  
   frontend:
     image: shuknow-frontend-local
     pull_policy: never

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -80,6 +80,12 @@ Workflow: `.github/workflows/publish-docker-ghcr.yml`
 docker compose --env-file .env.prod -f compose.prod.yaml -f compose.override.yaml up -d --build
 ```
 
+Для миграции:
+
+```bash
+docker compose --env-file .env.prod -f compose.prod.yaml -f compose.override.yaml up migrator --build
+```
+
 Этот режим:
 
 - не запускает `certbot-init` и `certbot`;

--- a/frontend/src/api/chatService.ts
+++ b/frontend/src/api/chatService.ts
@@ -20,7 +20,7 @@ export interface ChatMessageDto {
   id: string;
   role: "User" | "Ai" | "System";
   content: string;
-  index?: number | null;
+  createdAt: string;
   attachments?: AttachmentDto[] | null;
 }
 

--- a/frontend/src/mocks/handlers/chat.ts
+++ b/frontend/src/mocks/handlers/chat.ts
@@ -34,7 +34,18 @@ export const chatHandlers = [
   // GET /api/chat/session/messages
   http.get(`${API_BASE}/chat/session/messages`, () => {
     return HttpResponse.json({
-      items: [],
+      items: [] as Array<{
+        id: string;
+        role: "User" | "Ai" | "System";
+        content: string;
+        createdAt: string;
+        attachments?: Array<{
+          id: string;
+          fileName: string;
+          contentType: string;
+          sizeBytes: number;
+        }> | null;
+      }>,
       nextCursor: null,
       hasMore: false,
     });


### PR DESCRIPTION
Resolves #126

# Что сделано
- Исправил баг неверного порядка сообщений при отправке этих сообщений в контекст ллм
- У ChatMessage сменил поле Index на CreatedAt
- Обновил frontend, опираясь на изменения